### PR TITLE
Add a DomBackend::new_by_id()

### DIFF
--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -1,18 +1,17 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
-use ratzilla::event::KeyCode;
-use ratzilla::utils::set_document_title;
-use ratzilla::widgets::Hyperlink;
-use ratzilla::DomBackend;
-use ratzilla::WebRenderer;
+use ratzilla::{
+    event::KeyCode, utils::set_document_title, widgets::Hyperlink, DomBackend, WebRenderer,
+};
 
 use ratzilla::ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Style, Stylize},
     symbols::Marker,
-    widgets::canvas::{Canvas, Circle},
-    widgets::{Block, Paragraph, Widget},
+    widgets::{
+        canvas::{Canvas, Circle},
+        Block, Paragraph, Widget,
+    },
     Terminal,
 };
 


### PR DESCRIPTION
This attaches the backend  to an element specified by HTML id, instead of the body element, and allows more than one screen in one page.  This isn't extensively tested, but seems to work in a PoC.

Fixes #46 .