### PR TITLE
fix(examples): remove failing ratzilla.js imports from exampeles

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ WebAssembly) as a JavaScript module.
     </style>
   </head>
   <body>
-  <!-- (optional) subscribe to the application started event -->
-  <script type="module">
-    window.addEventListener("TrunkApplicationStarted", (_) => {
-      // window.wasmBindings.* are now available
-      console.log("application initialized");
-    });
-  </script>
+    <!-- (optional) subscribe to the application started event -->
+    <script type="module">
+      window.addEventListener("TrunkApplicationStarted", (_) => {
+        // #[wasm_bindgen] functions are now bound to window.wasmBindings.*
+        console.log("application initialized");
+      });
+    </script>
   </body>
 </html>
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ fn main() -> io::Result<()> {
 }
 ```
 
-Then add your `index.html` which imports the JavaScript module:
+Add your `index.html`. During build, `trunk` will automatically inject and initialize your Rust code (compiled to
+WebAssembly) as a JavaScript module.
 
 <details>
   <summary>index.html</summary>
@@ -111,6 +112,7 @@ Then add your `index.html` which imports the JavaScript module:
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/fira_code.min.css"
     />
+    <link data-trunk rel="rust"/>
     <title>Ratzilla</title>
     <style>
       body {
@@ -132,10 +134,13 @@ Then add your `index.html` which imports the JavaScript module:
     </style>
   </head>
   <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
+  <!-- (optional) subscribe to the application started event -->
+  <script type="module">
+    window.addEventListener("TrunkApplicationStarted", (_) => {
+      // window.wasmBindings.* are now available
+      console.log("application initialized");
+    });
+  </script>
   </body>
 </html>
 ```

--- a/examples/animations/index.html
+++ b/examples/animations/index.html
@@ -10,6 +10,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/fira_code.min.css"
     />
+    <link data-trunk rel="rust"/>
     <title>Animations</title>
     <style>
       body {
@@ -30,10 +31,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/colors_rgb/index.html
+++ b/examples/colors_rgb/index.html
@@ -23,10 +23,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -21,10 +21,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/demo2/index.html
+++ b/examples/demo2/index.html
@@ -30,10 +30,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/minimal/index.html
+++ b/examples/minimal/index.html
@@ -30,10 +30,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/pong/index.html
+++ b/examples/pong/index.html
@@ -24,10 +24,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/tauri/index.html
+++ b/examples/tauri/index.html
@@ -30,10 +30,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/text_area/index.html
+++ b/examples/text_area/index.html
@@ -30,10 +30,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/website/index.html
+++ b/examples/website/index.html
@@ -33,10 +33,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>

--- a/examples/world_map/index.html
+++ b/examples/world_map/index.html
@@ -30,10 +30,5 @@
       }
     </style>
   </head>
-  <body>
-    <script type="module">
-      import init from "./pkg/ratzilla.js";
-      init();
-    </script>
-  </body>
+  <body></body>
 </html>


### PR DESCRIPTION
"During build, `trunk` will automatically inject and initialize your Rust code (compiled to
WebAssembly) as a JavaScript module" so there's no need to manually import ratzilla.js. in fact, it fails:

![image](https://github.com/user-attachments/assets/2733123f-fb5d-44bf-afe0-37b2be43aced)

I removed the import from all the examples + updated the readme to reflect the change.