### PR TITLE
feat: Mouse Events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ web-sys = { version = "0.3.77", features = [
     'HtmlElement',
     'KeyboardEvent',
     'Location',
+    'MouseEvent',
     'Navigator',
     'Node',
     'Performance',

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -7,10 +7,13 @@ use ratzilla::ratatui::{
     Terminal,
 };
 
-use ratzilla::{event::KeyCode, DomBackend, WebRenderer};
+use ratzilla::{event::KeyCode, event::MouseEventKind, event::MouseButton, DomBackend, WebRenderer};
 
 fn main() -> io::Result<()> {
     let counter = Rc::new(RefCell::new(0));
+    let mouse_position = Rc::new(RefCell::new((0, 0)));
+    let mouse_button = Rc::new(RefCell::new(None::<MouseButton>));
+    let mouse_event_kind = Rc::new(RefCell::new(None::<MouseEventKind>));
     let backend = DomBackend::new()?;
     let terminal = Terminal::new(backend)?;
 
@@ -24,10 +27,28 @@ fn main() -> io::Result<()> {
         }
     });
 
+    terminal.on_mouse_event({
+        let mouse_position_cloned = mouse_position.clone();
+        let mouse_button_cloned = mouse_button.clone();
+        let mouse_event_kind_cloned = mouse_event_kind.clone();
+        move |mouse_event| {
+            let mut mouse_position = mouse_position_cloned.borrow_mut();
+            *mouse_position = (mouse_event.x, mouse_event.y);
+            let mut mouse_button = mouse_button_cloned.borrow_mut();
+            *mouse_button = Some(mouse_event.button);
+            let mut mouse_event_kind = mouse_event_kind_cloned.borrow_mut();
+            *mouse_event_kind = Some(mouse_event.event);
+        }
+    });
+
     terminal.draw_web(move |f| {
         let counter = counter.borrow();
+        let mouse_position = mouse_position.borrow();
+        let mouse_button = mouse_button.borrow();
+        let mouse_event_kind = mouse_event_kind.borrow();
+
         f.render_widget(
-            Paragraph::new(format!("Count: {counter}"))
+            Paragraph::new(format!("Count: {counter}\nMouseX: {:?}, MouseY: {:?}\nMouseButton: {:?}\nMouseEvent: {:?}", mouse_position.0, mouse_position.1, mouse_button, mouse_event_kind))
                 .alignment(Alignment::Center)
                 .block(
                     Block::bordered()

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -7,13 +7,16 @@ use ratzilla::ratatui::{
     Terminal,
 };
 
-use ratzilla::{event::KeyCode, event::MouseEventKind, event::MouseButton, DomBackend, WebRenderer};
+use ratzilla::{
+    event::KeyCode, event::MouseButton, event::MouseEventKind, DomBackend, WebRenderer,
+};
 
 fn main() -> io::Result<()> {
     let counter = Rc::new(RefCell::new(0));
     let mouse_position = Rc::new(RefCell::new((0, 0)));
     let mouse_button = Rc::new(RefCell::new(None::<MouseButton>));
     let mouse_event_kind = Rc::new(RefCell::new(None::<MouseEventKind>));
+
     let backend = DomBackend::new()?;
     let terminal = Terminal::new(backend)?;
 
@@ -48,14 +51,21 @@ fn main() -> io::Result<()> {
         let mouse_event_kind = mouse_event_kind.borrow();
 
         f.render_widget(
-            Paragraph::new(format!("Count: {counter}\nMouseX: {:?}, MouseY: {:?}\nMouseButton: {:?}\nMouseEvent: {:?}", mouse_position.0, mouse_position.1, mouse_button, mouse_event_kind))
-                .alignment(Alignment::Center)
-                .block(
-                    Block::bordered()
-                        .title("Ratzilla")
-                        .title_alignment(Alignment::Center)
-                        .border_style(Color::Yellow),
-                ),
+            Paragraph::new(format!(
+                "Space pressed: {counter}\n\
+                MouseX: {:?}\n\
+                MouseY: {:?}\n\
+                MouseButton: {mouse_button:?}\n\
+                MouseEvent: {mouse_event_kind:?}",
+                mouse_position.0, mouse_position.1
+            ))
+            .alignment(Alignment::Center)
+            .block(
+                Block::bordered()
+                    .title("Ratzilla")
+                    .title_alignment(Alignment::Center)
+                    .border_style(Color::Yellow),
+            ),
             f.area(),
         );
     });

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,6 +11,25 @@ pub struct KeyEvent {
     pub shift: bool,
 }
 
+/// A mouse movement event.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MouseEvent {
+    /// The mouse button that was pressed.
+    pub button: MouseButton,
+    /// The triggered event.
+    pub event: MouseEventKind,
+    /// The x coordinate of the mouse.
+    pub x: u32,
+    /// The y coordinate of the mouse.
+    pub y: u32,
+    /// Whether the control key is pressed.
+    pub ctrl: bool,
+    /// Whether the alt key is pressed.
+    pub alt: bool,
+    /// Whether the shift key is pressed.
+    pub shift: bool,
+}
+
 /// Convert a [`web_sys::KeyboardEvent`] to a [`KeyEvent`].
 impl From<web_sys::KeyboardEvent> for KeyEvent {
     fn from(event: web_sys::KeyboardEvent) -> Self {
@@ -102,6 +121,87 @@ impl From<web_sys::KeyboardEvent> for KeyCode {
             "PageDown" => KeyCode::PageDown,
             "Escape" => KeyCode::Esc,
             _ => KeyCode::Unidentified,
+        }
+    }
+}
+
+/// A mouse button.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MouseButton {
+    /// Left mouse button
+    Left,
+    /// Right mouse button
+    Right,
+    /// Middle mouse button
+    Middle,
+    /// Back mouse button
+    Back,
+    /// Forward mouse button
+    Forward,
+    /// Unidentified mouse button
+    Unidentified,
+}
+
+/// A mouse event.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MouseEventKind {
+    /// Mouse moved
+    Moved,
+    /// Mouse button pressed
+    Pressed,
+    /// Mouse button released
+    Released,
+    /// Unidentified mouse event
+    Unidentified,
+}
+
+/// Convert a [`web_sys::MouseEvent`] to a [`MouseEvent`].
+impl From<web_sys::MouseEvent> for MouseEvent {
+    fn from(event: web_sys::MouseEvent) -> Self {
+        let ctrl = event.ctrl_key();
+        let alt = event.alt_key();
+        let shift = event.shift_key();
+        let event_type = event.type_().into();
+        MouseEvent {
+            // Button is only valid if it is a mousedown or mouseup event.
+            button: if event_type == MouseEventKind::Moved {
+                MouseButton::Unidentified
+            } else {
+                event.button().into()
+            },
+            event: event_type,
+            x: event.client_x() as u32,
+            y: event.client_y() as u32,
+            ctrl,
+            alt,
+            shift,
+        }
+    }
+}
+
+/// Convert a [`web_sys::MouseEvent`] to a [`MouseButton`].
+impl From<i16> for MouseButton {
+    fn from(button: i16) -> Self {
+        match button {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            3 => MouseButton::Back,
+            4 => MouseButton::Forward,
+            _ => MouseButton::Unidentified,
+        }
+    }
+}
+
+/// Convert a [`web_sys::MouseEvent`] to a [`MouseEventKind`].
+impl From<String> for MouseEventKind {
+    fn from(event: String) -> Self {
+        let event = event.as_str();
+        match event {
+            "mousemove" => MouseEventKind::Moved,
+            "mousedown" => MouseEventKind::Pressed,
+            "mouseup" => MouseEventKind::Released,
+            _ => MouseEventKind::Unidentified,
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use ratatui::{prelude::Backend, Frame, Terminal};
 use std::{cell::RefCell, rc::Rc};
 use web_sys::{wasm_bindgen::prelude::*, window};
 
-use crate::event::KeyEvent;
+use crate::event::{MouseEvent, KeyEvent};
 
 /// Trait for rendering on the web.
 ///
@@ -36,6 +36,31 @@ pub trait WebRenderer {
         let document = window.document().unwrap();
         document
             .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    /// Handles mouse events.
+    /// 
+    /// This method takes a closure that will be called on every `mousemove`, 'mousedown', and `mouseup`
+    /// event.
+    fn on_mouse_event<F>(&self, mut callback: F)
+    where
+        F: FnMut(MouseEvent) + 'static,
+    {
+        let closure = Closure::<dyn FnMut(_)>::new(move |event: web_sys::MouseEvent| {
+            callback(event.into());
+        });
+        let window = window().unwrap();
+        let document = window.document().unwrap();
+        document
+            .add_event_listener_with_callback("mousemove", closure.as_ref().unchecked_ref())
+            .unwrap();
+        document
+            .add_event_listener_with_callback("mousedown", closure.as_ref().unchecked_ref())
+            .unwrap();
+        document
+            .add_event_listener_with_callback("mouseup", closure.as_ref().unchecked_ref())
             .unwrap();
         closure.forget();
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use ratatui::{prelude::Backend, Frame, Terminal};
 use std::{cell::RefCell, rc::Rc};
 use web_sys::{wasm_bindgen::prelude::*, window};
 
-use crate::event::{MouseEvent, KeyEvent};
+use crate::event::{KeyEvent, MouseEvent};
 
 /// Trait for rendering on the web.
 ///
@@ -41,7 +41,7 @@ pub trait WebRenderer {
     }
 
     /// Handles mouse events.
-    /// 
+    ///
     /// This method takes a closure that will be called on every `mousemove`, 'mousedown', and `mouseup`
     /// event.
     fn on_mouse_event<F>(&self, mut callback: F)


### PR DESCRIPTION
Fixes #105 

Adds a simple callback for capturing mouse events on `mousemove`, `mousedown` and `mouseup`, and makes use of it in the minimal example.

If a separate example is a better choice, or a new one is required, I'll gladly make one and leave minimal as it was.