### PR TITLE
fix(dom): ensure consistent width for braille characters

### DIFF
--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -36,7 +36,7 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
-    let app_state = Rc::new(RefCell::new(App::new("Demo", false)));
+    let app_state = Rc::new(RefCell::new(App::new("Demo", true)));
     
     // Create backend with explicit size like main branch (1600x900)
     let canvas_options = CanvasBackendOptions::new()

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -84,7 +84,14 @@ pub(crate) fn get_cell_style_as_css(cell: &Cell) -> String {
         modifier_style.push_str("text-decoration: line-through; ");
     }
 
-    format!("{fg_style} {bg_style} {modifier_style}")
+    // ensure consistent width for braille characters
+    let braille_style = if contains_braille(cell) {
+        "display: inline-block; width: 1ch; font-variant-numeric: tabular-nums; "
+    } else {
+        ""
+    };
+
+    format!("{fg_style} {bg_style} {modifier_style}{braille_style}")
 }
 
 /// Converts a Color to a CSS style.
@@ -185,4 +192,12 @@ pub(crate) fn create_canvas_in_element(
     parent.append_child(&element)?;
 
     Ok(canvas)
+}
+
+/// Checks if the given cell contains a braille character.
+fn contains_braille(cell: &Cell) -> bool {
+    cell.symbol()
+        .chars()
+        .next()
+        .is_some_and(|c| ('\u{2800}'..='\u{28FF}').contains(&c))
 }


### PR DESCRIPTION
this PR addresses #118 by introducing special handling of braille character to ensure they align correctly.  

<img width="789" height="453" alt="image" src="https://github.com/user-attachments/assets/ea37ceb0-d516-4f6a-a3af-24c79c0d7e22" />

i changed the default marker in `examples/demo` dot to braille (looks better, but more importantly, it was the only place where the issue compounded to the point where it was visible).