### PR TITLE
feat(dom): multi-width unicode character support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "console_error_panic_hook",
  "ratatui",
  "thiserror",
+ "unicode-width 0.2.0",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ console_error_panic_hook = "0.1.7"
 thiserror = "2.0.12"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
 beamterm-renderer = "0.1.1"
+unicode-width = "0.2.0"

--- a/examples/unicode/Cargo.toml
+++ b/examples/unicode/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "minimal"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ratzilla = { path = "../../" }
+examples-shared = { path = "../shared" }

--- a/examples/unicode/index.html
+++ b/examples/unicode/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <link rel="preload" as="style" crossorigin href="https://fontsapi.zeoseven.com/442/main/result.css"
+    onload="this.rel='stylesheet'" onerror="this.href='https://fontsapi-storage.zeoseven.com/442/main/result.css'" />
+  <noscript>
+    <link rel="stylesheet" href="https://fontsapi.zeoseven.com/442/main/result.css" />
+  </noscript>
+  <title>Ratzilla</title>
+  <style>
+    body {
+      margin: 0;
+      width: 100%;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      align-content: center;
+      background-color: #121212;
+    }
+
+    pre {
+      font-family: "Maple Mono NF CN", monospace;
+      font-size: 15px;
+      margin: 0px;
+    }
+  </style>
+</head>
+
+<body></body>
+
+</html>

--- a/examples/unicode/src/main.rs
+++ b/examples/unicode/src/main.rs
@@ -1,0 +1,40 @@
+use std::io;
+
+use ratzilla::ratatui::{
+    layout::Alignment,
+    style::Color,
+    widgets::{Block, Paragraph},
+};
+
+use ratzilla::WebRenderer;
+
+use examples_shared::backend::{BackendType, MultiBackendBuilder};
+
+fn main() -> io::Result<()> {
+    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom).build_terminal()?;
+
+    terminal.draw_web(move |f| {
+        f.render_widget(
+            Paragraph::new(
+                [
+                    "Hello, world!",
+                    "你好，世界！",
+                    "世界、こんにちは。",
+                    // "헬로우 월드！",
+                    // "👨💻👋🌐",
+                ]
+                .join("\n"),
+            )
+            .alignment(Alignment::Center)
+            .block(
+                Block::bordered()
+                    .title("Ratzilla")
+                    .title_alignment(Alignment::Center)
+                    .border_style(Color::Yellow),
+            ),
+            f.area(),
+        );
+    });
+
+    Ok(())
+}

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -14,23 +14,31 @@ use web_sys::{
 };
 
 /// Creates a new `<span>` element with the given cell.
-pub(crate) fn create_span(document: &Document, cell: &Cell) -> Result<Element, Error> {
+pub(crate) fn create_span(
+    document: &Document,
+    cell: &Cell,
+    overwritten: bool,
+) -> Result<Element, Error> {
     let span = document.create_element("span")?;
     span.set_inner_html(cell.symbol());
 
-    let style = get_cell_style_as_css(cell);
-    span.set_attribute("style", &style)?;
+    if overwritten {
+        span.set_attribute("style", "display: none;")?;
+    } else {
+        let style = get_cell_style_as_css(cell);
+        span.set_attribute("style", &style)?;
+    }
     Ok(span)
 }
 
 /// Creates a new `<a>` element with the given cells.
-pub(crate) fn create_anchor(document: &Document, cells: &[Cell]) -> Result<Element, Error> {
+pub(crate) fn create_anchor(document: &Document, cells: &[(Cell, bool)]) -> Result<Element, Error> {
     let anchor = document.create_element("a")?;
     anchor.set_attribute(
         "href",
-        &cells.iter().map(|c| c.symbol()).collect::<String>(),
+        &cells.iter().map(|c| c.0.symbol()).collect::<String>(),
     )?;
-    anchor.set_attribute("style", &get_cell_style_as_css(&cells[0]))?;
+    anchor.set_attribute("style", &get_cell_style_as_css(&cells[0].0))?;
     Ok(anchor)
 }
 


### PR DESCRIPTION
This Pull Request introduces functionality to properly display multi-width Unicode characters (such as Chinese characters and Japanese kana) in `DomBackend`. It sets the cell following a multi-width Unicode character to `display: none`, ensuring the correct width is maintained.

<img width="686" height="336" alt="Screenshot" src="https://github.com/user-attachments/assets/68c17248-3a68-4370-80c3-d92b0f0a0a59" />

Limitations:

1. This implementation depends on specific fonts that must render CJK characters and Latin letters in an exact 2:1 width ratio. The font used in the example, Maple Mono CN, supports this feature for Chinese characters and Japanese kana but does not maintain the 2:1 ratio for Korean Hangul or emojis. As a result, misalignment may occur when displaying Korean text or emojis.
2. Occasionally, misalignment may occur after resizing the window. The cause of this issue remains unclear.
