### PR TITLE
chore(deps): bump beamterm from 0.7.0 to 0.8.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "beamterm-data"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9440270ceba7fccbd5aab22ffba8abafd13b63d30bc42c417b622fcc9643d7"
+checksum = "03a460829990fe27b44ebdd2864258078955b0181a3d0d0ca32014d098eb756b"
 dependencies = [
  "compact_str 0.9.0",
  "miniz_oxide",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-renderer"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100e6159f2cd12ca83f89adaa812966d221616510c0a09afd4e1ea8e0f704bfb"
+checksum = "11d0f031d2e6c679e46cfcd03c6443b760338467d2191423e8d7e663153ca670"
 dependencies = [
  "beamterm-data",
  "compact_str 0.9.0",
@@ -479,18 +479,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ ratatui = { version = "0.29", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.12"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.7.0"
+beamterm-renderer = "0.8.0"


### PR DESCRIPTION
## notable changes

- *(renderer)* Double-width emoji support (supports up to 2048 emoji)
- *(atlas)* fix Glyph mismatch from truncated conversion (was visible in slide in/out with motion left/right)
- *(font)* Hack 14.94pt 11x18 with Noto Color Emoji (same as before but embellished with emoji)

No API changes in 0.8.0.