### PR TITLE
Remove Jet Pham's Conway's Game of Life link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ There is a Vercel deployment template available for Ratzilla [here](https://verc
 - <https://terminalcollective.org> - Terminal Collective community website
 - <https://www.function-type.com/tusistor> - Resistor calculator
 - <http://timbeck.me> - Personal website of Tim Beck
-- <https://jetpham.com> - Conway's Game of Life
 - <https://map.apt-swarm.orca.toys> - Map of apt-swarm p2p locations
 - [TachyonFX FTL](https://junkdog.github.io/tachyonfx-ftl/) - DSL editor and previewer for TachyonFX effects
 - <https://emrecansuster.com> - Personal website of Emrecan Şuşter ([source](https://github.com/Tarbetu/website))


### PR DESCRIPTION
Removed link to Jet Pham's Conway's Game of Life from the README.

I have since changed my website to no longer use ratzilla, but I really love the project!