### PR TITLE
chore(deps): bump beamterm to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "beamterm-data"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a460829990fe27b44ebdd2864258078955b0181a3d0d0ca32014d098eb756b"
+checksum = "6ec23288601a0db47b9224b997533731dec82fa6385ac97113c03ddcc3ef3981"
 dependencies = [
  "compact_str 0.9.0",
  "miniz_oxide",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-renderer"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d0f031d2e6c679e46cfcd03c6443b760338467d2191423e8d7e663153ca670"
+checksum = "dcf31d90625de3a8ab623bfacff669324d7d687b0206e4f0c6e62ff704952184"
 dependencies = [
  "beamterm-data",
  "compact_str 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ ratatui = { version = "0.29", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.12"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.8.0"
+beamterm-renderer = "0.9.0"


### PR DESCRIPTION
this fixes rendering issues related to [fullwidth](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms) glyphs mentioned in https://github.com/orhun/ratzilla/issues/135