### PR TITLE
feat(mouse): enhance mouse events with grid coordinates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ web-sys = { version = "0.3.81", features = [
     'console',
     'CanvasRenderingContext2d',
     'Document',
+    'DomRect',
     'Element',
     'HtmlCanvasElement',
     'HtmlElement',

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ use ratzilla::{event::KeyCode, DomBackend, WebRenderer};
 fn main() -> io::Result<()> {
     let counter = Rc::new(RefCell::new(0));
     let backend = DomBackend::new()?;
-    let terminal = Terminal::new(backend)?;
+    let mut terminal = Terminal::new(backend)?;
 
     terminal.on_key_event({
         let counter_cloned = counter.clone();
@@ -72,7 +72,7 @@ fn main() -> io::Result<()> {
                 *counter += 1;
             }
         }
-    });
+    })?;
 
     terminal.draw_web(move |f| {
         let counter = counter.borrow();

--- a/examples/canvas_stress_test/src/main.rs
+++ b/examples/canvas_stress_test/src/main.rs
@@ -20,7 +20,7 @@ use std::{cell::RefCell, rc::Rc};
 
 fn main() -> std::io::Result<()> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::WebGl2)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::WebGl2)
         .webgl2_options(WebGl2BackendOptions::new().measure_performance(true))
         .build_terminal()?;
 
@@ -35,7 +35,7 @@ fn main() -> std::io::Result<()> {
         let current = text_style_key_event.as_ref();
         let next = current.borrow().clone() + 1;
         *current.borrow_mut() = next % WidgetCache::SCREEN_TYPES;
-    });
+    })?;
 
     // Pre-generate widgets for better performance; in particular,
     // this avoids excessive GC pressure in the JS heap.

--- a/examples/clipboard/src/main.rs
+++ b/examples/clipboard/src/main.rs
@@ -24,12 +24,12 @@ fn main() -> io::Result<()> {
 
     let state = Rc::new(App::default());
     let event_state = Rc::clone(&state);
-    let _ = terminal.on_key_event(move |key_event| {
+    terminal.on_key_event(move |key_event| {
         let event_state = event_state.clone();
         wasm_bindgen_futures::spawn_local(
             async move { event_state.handle_events(key_event).await },
         );
-    });
+    })?;
 
     let render_state = Rc::clone(&state);
     terminal.draw_web(move |frame| {

--- a/examples/clipboard/src/main.rs
+++ b/examples/clipboard/src/main.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::Alignment,
     style::{Color, Stylize},
     widgets::{Block, BorderType, Paragraph},
-    Frame, Terminal,
+    Frame,
 };
 
 use ratzilla::{event::{KeyCode, KeyEvent}, SelectionMode, WebRenderer};
@@ -18,13 +18,13 @@ fn main() -> io::Result<()> {
         .enable_mouse_selection_with_mode(SelectionMode::Linear)
         .measure_performance(true);
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .webgl2_options(webgl2_options)
         .build_terminal()?;
 
     let state = Rc::new(App::default());
     let event_state = Rc::clone(&state);
-    terminal.on_key_event(move |key_event| {
+    let _ = terminal.on_key_event(move |key_event| {
         let event_state = event_state.clone();
         wasm_bindgen_futures::spawn_local(
             async move { event_state.handle_events(key_event).await },

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -12,7 +12,7 @@ use app::App;
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
 use ratzilla::event::KeyCode;
 use ratzilla::WebRenderer;
-use ratzilla::{backend::canvas::CanvasBackendOptions, backend::webgl2::WebGl2BackendOptions};
+use ratzilla::backend::webgl2::WebGl2BackendOptions;
 
 mod app;
 
@@ -28,11 +28,11 @@ fn main() -> Result<()> {
         .enable_mouse_selection()
         .disable_auto_css_resize(); // canvas size managed by css in index.html
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::WebGl2)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::WebGl2)
         .webgl2_options(webgl2_options)
         .build_terminal()?;
 
-    terminal.on_key_event({
+    let _ = terminal.on_key_event({
         let app_state_cloned = app_state.clone();
         move |event| {
             let mut app_state = app_state_cloned.borrow_mut();

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
         .webgl2_options(webgl2_options)
         .build_terminal()?;
 
-    let _ = terminal.on_key_event({
+    terminal.on_key_event({
         let app_state_cloned = app_state.clone();
         move |event| {
             let mut app_state = app_state_cloned.borrow_mut();
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
                 _ => {}
             }
         }
-    });
+    })?;
 
     terminal.draw_web(move |f| {
         let mut app_state = app_state.borrow_mut();

--- a/examples/demo2/src/main.rs
+++ b/examples/demo2/src/main.rs
@@ -29,7 +29,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use app::App;
 use ratzilla::{
-    backend::webgl2::WebGl2BackendOptions,
+    backend::webgl2::{SelectionMode, WebGl2BackendOptions},
     ratatui::{layout::Rect, TerminalOptions, Viewport},
     WebRenderer,
 };
@@ -47,17 +47,17 @@ fn main() -> std::io::Result<()> {
     // using vhs in a 1280x640 sized window (github social preview size)
     let viewport = Viewport::Fixed(Rect::new(0, 0, 81, 18));
     
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Canvas)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Canvas)
         .webgl2_options(WebGl2BackendOptions::new()
             .measure_performance(true)
-            .enable_mouse_selection()
+            .enable_mouse_selection_with_mode(SelectionMode::default())
             .enable_console_debug_api()
         )
         .terminal_options(TerminalOptions { viewport })
         .build_terminal()?;
     
     let app = Rc::new(RefCell::new(App::default()));
-    terminal.on_key_event({
+    let _ = terminal.on_key_event({
         let app = app.clone();
         move |key_event| {
             app.borrow_mut().handle_key_press(key_event);

--- a/examples/demo2/src/main.rs
+++ b/examples/demo2/src/main.rs
@@ -57,12 +57,12 @@ fn main() -> std::io::Result<()> {
         .build_terminal()?;
     
     let app = Rc::new(RefCell::new(App::default()));
-    let _ = terminal.on_key_event({
+    terminal.on_key_event({
         let app = app.clone();
         move |key_event| {
             app.borrow_mut().handle_key_press(key_event);
         }
-    });
+    })?;
     terminal.draw_web(move |f| {
         let app = app.borrow_mut();
         app.draw(f);

--- a/examples/demo2/src/tabs/weather.rs
+++ b/examples/demo2/src/tabs/weather.rs
@@ -3,7 +3,7 @@ use palette::Okhsv;
 use ratzilla::ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::{Color, Style},
     symbols,
     widgets::{
         calendar::{CalendarEventStore, Monthly},

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> io::Result<()> {
     let mouse_button = Rc::new(RefCell::new(None::<MouseButton>));
     let mouse_event_kind = Rc::new(RefCell::new(None::<MouseEventKind>));
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .webgl2_options(WebGl2BackendOptions::new()
             .enable_console_debug_api()
             .enable_mouse_selection()
@@ -34,21 +34,38 @@ fn main() -> io::Result<()> {
                 *counter += 1;
             }
         }
-    });
+    })?;
 
     terminal.on_mouse_event({
         let mouse_position_cloned = mouse_position.clone();
         let mouse_button_cloned = mouse_button.clone();
         let mouse_event_kind_cloned = mouse_event_kind.clone();
         move |mouse_event| {
+            let btn = match mouse_event.kind {
+                MouseEventKind::Moved => None,
+                MouseEventKind::ButtonDown(btn) => Some(btn),
+                MouseEventKind::ButtonUp(btn) => Some(btn),
+                MouseEventKind::SingleClick(_) |
+                MouseEventKind::DoubleClick(_) |
+                MouseEventKind::Exited  |
+                MouseEventKind::Entered |
+                MouseEventKind::Unidentified => {
+                    return;
+                }
+            };
+
+
             let mut mouse_position = mouse_position_cloned.borrow_mut();
-            *mouse_position = (mouse_event.x, mouse_event.y);
+            *mouse_position = (mouse_event.col, mouse_event.row);
             let mut mouse_button = mouse_button_cloned.borrow_mut();
-            *mouse_button = Some(mouse_event.button);
+            *mouse_button = btn;
             let mut mouse_event_kind = mouse_event_kind_cloned.borrow_mut();
-            *mouse_event_kind = Some(mouse_event.event);
+            *mouse_event_kind = Some(mouse_event.kind);
         }
-    });
+    })?;
+
+    // Gruvbox bright orange
+    const HOVER_BG: Color = Color::Rgb(254, 128, 25);
 
     terminal.draw_web(move |f| {
         let counter = counter.borrow();
@@ -74,6 +91,13 @@ fn main() -> io::Result<()> {
             ),
             f.area(),
         );
+
+        // Highlight the hovered cell
+        let (col, row) = *mouse_position;
+        let area = f.area();
+        if col < area.width && row < area.height {
+            f.buffer_mut()[(col, row)].set_bg(HOVER_BG);
+        }
     });
 
     Ok(())

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -43,13 +43,7 @@ fn main() -> io::Result<()> {
                 MouseEventKind::Moved => None,
                 MouseEventKind::ButtonDown(btn) => Some(btn),
                 MouseEventKind::ButtonUp(btn) => Some(btn),
-                MouseEventKind::SingleClick(_) |
-                MouseEventKind::DoubleClick(_) |
-                MouseEventKind::Exited  |
-                MouseEventKind::Entered |
-                MouseEventKind::Unidentified => {
-                    return;
-                }
+                _ => return
             };
 
 

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -6,9 +6,7 @@ use ratzilla::ratatui::{
     widgets::{Block, Paragraph},
 };
 
-use ratzilla::{
-    event::KeyCode, event::MouseButton, event::MouseEventKind, WebRenderer,
-};
+use ratzilla::{event::KeyCode, event::MouseButton, event::MouseEventKind, SelectionMode, WebRenderer};
 
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
 use ratzilla::backend::webgl2::WebGl2BackendOptions;
@@ -22,7 +20,7 @@ fn main() -> io::Result<()> {
     let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .webgl2_options(WebGl2BackendOptions::new()
             .enable_console_debug_api()
-            .enable_mouse_selection()
+            .enable_mouse_selection_with_mode(SelectionMode::Block)
         )
         .build_terminal()?;
 

--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> std::io::Result<()> {
         .dom_options(DomBackendOptions::new(Some("container".into()), CursorShape::SteadyBlock))
         .build_terminal()?;
 
-    let _ = terminal.on_key_event({
+    terminal.on_key_event({
         let app_state_cloned = app_state.clone();
         move |event| {
             let mut app_state = app_state_cloned.borrow_mut();
@@ -96,7 +96,7 @@ fn main() -> std::io::Result<()> {
                 _ => {}
             }
         }
-    });
+    })?;
     terminal.draw_web(move |f| {
         let mut app_state = app_state.borrow_mut();
         app_state.count += 1;

--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -14,7 +14,7 @@ use ratzilla::ratatui::{
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
 use ratzilla::backend::canvas::CanvasBackendOptions;
 use ratzilla::backend::dom::DomBackendOptions;
-use ratzilla::backend::webgl2::WebGl2BackendOptions;
+use ratzilla::backend::webgl2::{SelectionMode, WebGl2BackendOptions};
 
 struct App {
     count: u64,
@@ -65,11 +65,11 @@ fn main() -> std::io::Result<()> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     let app_state = Rc::new(RefCell::new(App::new()));
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .webgl2_options(WebGl2BackendOptions::new()
             .grid_id("container")
             .enable_hyperlinks()
-            .enable_mouse_selection()
+            .enable_mouse_selection_with_mode(SelectionMode::default())
         )
         .canvas_options(CanvasBackendOptions::new()
             .grid_id("container")
@@ -77,7 +77,7 @@ fn main() -> std::io::Result<()> {
         .dom_options(DomBackendOptions::new(Some("container".into()), CursorShape::SteadyBlock))
         .build_terminal()?;
 
-    terminal.on_key_event({
+    let _ = terminal.on_key_event({
         let app_state_cloned = app_state.clone();
         move |event| {
             let mut app_state = app_state_cloned.borrow_mut();

--- a/examples/tauri/src/main.rs
+++ b/examples/tauri/src/main.rs
@@ -10,7 +10,6 @@ use ratzilla::{
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
 use tachyonfx::{
     fx, CenteredShrink, Duration, Effect, EffectRenderer, EffectTimer, Interpolation, Motion,
-    Shader,
 };
 
 fn main() -> io::Result<()> {

--- a/examples/text_area/src/main.rs
+++ b/examples/text_area/src/main.rs
@@ -13,11 +13,11 @@ use ratzilla::{
 fn main() -> io::Result<()> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom).build_terminal()?;
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom).build_terminal()?;
 
     let app = Rc::new(RefCell::new(App::new()));
 
-    terminal.on_key_event({
+    let _ = terminal.on_key_event({
         let event_state = app.clone();
         move |key_event| {
             let mut state = event_state.borrow_mut();

--- a/examples/text_area/src/main.rs
+++ b/examples/text_area/src/main.rs
@@ -17,13 +17,13 @@ fn main() -> io::Result<()> {
 
     let app = Rc::new(RefCell::new(App::new()));
 
-    let _ = terminal.on_key_event({
+    terminal.on_key_event({
         let event_state = app.clone();
         move |key_event| {
             let mut state = event_state.borrow_mut();
             state.handle_events(key_event);
         }
-    });
+    })?;
 
     terminal.draw_web({
         let render_state = app.clone();

--- a/examples/user_input/src/main.rs
+++ b/examples/user_input/src/main.rs
@@ -14,7 +14,7 @@ use ratzilla::ratatui::{
 use ratzilla::{event::KeyCode, WebRenderer};
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
 use ratzilla::backend::dom::DomBackendOptions;
-use ratzilla::backend::webgl2::WebGl2BackendOptions;
+use ratzilla::backend::webgl2::{SelectionMode, WebGl2BackendOptions};
 
 fn main() -> io::Result<()> {
     let dom_options = DomBackendOptions::new(None, CursorShape::SteadyUnderScore);
@@ -22,16 +22,16 @@ fn main() -> io::Result<()> {
     let webgl2_options = WebGl2BackendOptions::new()
         .cursor_shape(CursorShape::SteadyUnderScore)
         .enable_console_debug_api()
-        .enable_mouse_selection();
+        .enable_mouse_selection_with_mode(SelectionMode::default());
 
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .dom_options(dom_options)
         .webgl2_options(webgl2_options)
         .build_terminal()?;
 
     let app = Rc::new(RefCell::new(App::new()));
 
-    terminal.on_key_event({
+    let _ = terminal.on_key_event({
         let event_state = app.clone();
         move |key_event| {
             let mut state = event_state.borrow_mut();

--- a/examples/user_input/src/main.rs
+++ b/examples/user_input/src/main.rs
@@ -31,13 +31,13 @@ fn main() -> io::Result<()> {
 
     let app = Rc::new(RefCell::new(App::new()));
 
-    let _ = terminal.on_key_event({
+    terminal.on_key_event({
         let event_state = app.clone();
         move |key_event| {
             let mut state = event_state.borrow_mut();
             state.handle_events(key_event);
         }
-    });
+    })?;
 
     terminal.draw_web({
         let render_state = app.clone();

--- a/examples/website/src/main.rs
+++ b/examples/website/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> io::Result<()> {
         .build_terminal()?;
 
     let mut state = State::default();
-    let _ = terminal.on_key_event(move |key| handle_key_event(key));
+    terminal.on_key_event(move |key| handle_key_event(key))?;
     terminal.draw_web(move |f| ui(f, &mut state));
     Ok(())
 }

--- a/examples/website/src/main.rs
+++ b/examples/website/src/main.rs
@@ -16,7 +16,7 @@ use tachyonfx::{
     fx::{self, RepeatMode},
     CenteredShrink, Duration, Effect, EffectRenderer, EffectTimer, Interpolation, Motion, 
 };
-use ratzilla::backend::webgl2::WebGl2BackendOptions;
+use ratzilla::backend::webgl2::{SelectionMode, WebGl2BackendOptions};
 
 struct State {
     intro_effect: Effect,
@@ -56,15 +56,15 @@ impl Default for State {
 fn main() -> io::Result<()> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     
-    let terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
+    let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
         .webgl2_options(WebGl2BackendOptions::new()
             .enable_hyperlinks()
-            .enable_mouse_selection()
+            .enable_mouse_selection_with_mode(SelectionMode::default())
         )
         .build_terminal()?;
-    
+
     let mut state = State::default();
-    terminal.on_key_event(move |key| handle_key_event(key));
+    let _ = terminal.on_key_event(move |key| handle_key_event(key));
     terminal.draw_web(move |f| ui(f, &mut state));
     Ok(())
 }

--- a/examples/world_map/src/main.rs
+++ b/examples/world_map/src/main.rs
@@ -5,7 +5,6 @@ use ratzilla::ratatui::{
     widgets,
     widgets::canvas,
     style::Color,
-    Terminal,
 };
 
 use ratzilla::{WebRenderer};

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -118,6 +118,7 @@ impl Canvas {
 /// Canvas backend.
 ///
 /// This backend renders the buffer onto a HTML canvas element.
+#[derive(Debug)]
 pub struct CanvasBackend {
     /// Whether the canvas has been initialized.
     initialized: bool,
@@ -148,24 +149,6 @@ pub struct CanvasBackend {
 
 /// Type alias for mouse event callback state.
 type MouseCallbackState = EventCallback<web_sys::MouseEvent>;
-
-impl std::fmt::Debug for CanvasBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CanvasBackend")
-            .field("initialized", &self.initialized)
-            .field("always_clip_cells", &self.always_clip_cells)
-            .field(
-                "buffer",
-                &format!("[{}x{}]", self.buffer[0].len(), self.buffer.len()),
-            )
-            .field("cursor_position", &self.cursor_position)
-            .field("cursor_shape", &self.cursor_shape)
-            .field("debug_mode", &self.debug_mode)
-            .field("mouse_callback", &self.mouse_callback.is_some())
-            .field("key_callback", &self.key_callback.is_some())
-            .finish()
-    }
-}
 
 impl CanvasBackend {
     /// Constructs a new [`CanvasBackend`].
@@ -654,7 +637,7 @@ impl WebEventHandler for CanvasBackend {
 ///
 /// This reduces the number of draw calls to the canvas API by coalescing adjacent cells
 /// with identical colors into larger rectangles, which is particularly beneficial for
-/// WASM where calls are quiteexpensive.
+/// WASM where calls are quite expensive.
 struct RowColorOptimizer {
     /// The currently accumulating region and its color
     pending_region: Option<(Rect, Color)>,

--- a/src/backend/dom.rs
+++ b/src/backend/dom.rs
@@ -10,7 +10,7 @@ use ratatui::{
     layout::{Position, Size},
     prelude::{backend::ClearType, Backend},
 };
-use web_sys::{window, Document, Element, Window};
+use web_sys::{window, Document, Element};
 
 use unicode_width::UnicodeWidthStr;
 
@@ -81,8 +81,6 @@ pub struct DomBackend {
     grid: Element,
     /// The parent of the grid element.
     grid_parent: Element,
-    /// Window.
-    window: Window,
     /// Document.
     document: Document,
     /// Options.
@@ -96,7 +94,7 @@ pub struct DomBackend {
     /// Measured cell dimensions in pixels (width, height).
     cell_size: (f64, f64),
     /// Resize event callback handler.
-    resize_callback: EventCallback<web_sys::Event>,
+    _resize_callback: EventCallback<web_sys::Event>,
     /// Mouse event callback handler.
     mouse_callback: Option<DomMouseCallbackState>,
     /// Key event callback handler.
@@ -166,13 +164,12 @@ impl DomBackend {
             grid: document.create_element("div")?,
             grid_parent,
             options,
-            window,
             document,
             cursor_position: None,
             last_cursor_position: None,
             size,
             cell_size,
-            resize_callback,
+            _resize_callback: resize_callback,
             mouse_callback: None,
             key_callback: None,
         };

--- a/src/backend/event_callback.rs
+++ b/src/backend/event_callback.rs
@@ -3,6 +3,7 @@
 //! This module provides utilities for managing web event listeners with proper
 //! lifecycle management and coordinate translation for mouse events.
 
+use std::fmt::Formatter;
 use web_sys::{
     wasm_bindgen::{convert::FromWasmAbi, prelude::Closure, JsCast},
     Element,
@@ -61,6 +62,15 @@ impl<T: 'static> Drop for EventCallback<T> {
                 self.closure.as_ref().unchecked_ref(),
             );
         }
+    }
+}
+
+impl<T: 'static> std::fmt::Debug for EventCallback<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventCallback")
+            .field("event_types", &self.event_types)
+            .field("element", &self.element)
+            .finish()
     }
 }
 

--- a/src/backend/event_callback.rs
+++ b/src/backend/event_callback.rs
@@ -1,0 +1,212 @@
+//! Event callback management with automatic cleanup.
+//!
+//! This module provides utilities for managing web event listeners with proper
+//! lifecycle management and coordinate translation for mouse events.
+
+use web_sys::{
+    wasm_bindgen::{convert::FromWasmAbi, prelude::Closure, JsCast},
+    Element,
+};
+
+use crate::{
+    error::Error,
+    event::{MouseButton, MouseEvent, MouseEventKind},
+};
+
+/// Manages web event listeners with automatic cleanup.
+///
+/// When this struct is dropped, all registered event listeners are removed
+/// from the element, preventing memory leaks.
+pub(super) struct EventCallback<T: 'static> {
+    /// The event types this callback is registered for.
+    event_types: &'static [&'static str],
+    /// The element the listeners are attached to.
+    element: Element,
+    /// The closure that handles the events.
+    #[allow(dead_code)]
+    closure: Closure<dyn FnMut(T)>,
+}
+
+impl<T: 'static> EventCallback<T> {
+    /// Creates a new [`EventCallback`] and attaches listeners to the element.
+    pub fn new<F>(
+        element: Element,
+        event_types: &'static [&'static str],
+        callback: F,
+    ) -> Result<Self, Error>
+    where
+        F: FnMut(T) + 'static,
+        T: JsCast + FromWasmAbi,
+    {
+        let closure = Closure::<dyn FnMut(T)>::new(callback);
+
+        for event_type in event_types {
+            element
+                .add_event_listener_with_callback(event_type, closure.as_ref().unchecked_ref())?;
+        }
+
+        Ok(Self {
+            event_types,
+            element,
+            closure,
+        })
+    }
+}
+
+impl<T: 'static> Drop for EventCallback<T> {
+    fn drop(&mut self) {
+        for event_type in self.event_types {
+            let _ = self.element.remove_event_listener_with_callback(
+                event_type,
+                self.closure.as_ref().unchecked_ref(),
+            );
+        }
+    }
+}
+
+/// Configuration for mouse coordinate transformation.
+///
+/// This struct holds the information needed to translate raw pixel coordinates
+/// from mouse events into terminal grid coordinates.
+#[derive(Debug, Clone)]
+pub(super) struct MouseConfig {
+    /// Terminal grid width in characters.
+    pub grid_width: u16,
+    /// Terminal grid height in characters.
+    pub grid_height: u16,
+    /// Pixel offset from the element edge (e.g., canvas padding/translation).
+    pub offset: Option<f64>,
+    /// Cell dimensions in pixels (width, height).
+    /// If provided, used for pixel-perfect coordinate calculation.
+    pub cell_dimensions: Option<(f64, f64)>,
+}
+
+impl MouseConfig {
+    /// Creates a new [`MouseConfig`] with the given grid dimensions.
+    pub fn new(grid_width: u16, grid_height: u16) -> Self {
+        Self {
+            grid_width,
+            grid_height,
+            offset: None,
+            cell_dimensions: None,
+        }
+    }
+
+    /// Sets the pixel offset from the element edge.
+    pub fn with_offset(mut self, offset: f64) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Sets the cell dimensions in pixels.
+    pub fn with_cell_dimensions(mut self, width: f64, height: f64) -> Self {
+        self.cell_dimensions = Some((width, height));
+        self
+    }
+}
+
+/// The event types for keyboard events.
+pub(super) const KEY_EVENT_TYPES: &[&str] = &["keydown"];
+
+/// Mouse event types (excluding wheel which needs special handling).
+pub(super) const MOUSE_EVENT_TYPES: &[&str] = &[
+    "mousemove",
+    "mousedown",
+    "mouseup",
+    "click",
+    "dblclick",
+    "mouseenter",
+    "mouseleave",
+];
+
+/// Translates mouse event pixel coordinates to terminal grid coordinates.
+///
+/// This function calculates the grid position (col, row) from raw pixel
+/// coordinates, taking into account element positioning and optional offsets.
+pub(super) fn mouse_to_grid_coords(
+    event: &web_sys::MouseEvent,
+    element: &Element,
+    config: &MouseConfig,
+) -> (u16, u16) {
+    let rect = element.get_bounding_client_rect();
+
+    // Calculate relative position within element
+    let offset = config.offset.unwrap_or(0.0);
+    let relative_x = (event.client_x() as f64 - rect.left() - offset).max(0.0);
+    let relative_y = (event.client_y() as f64 - rect.top() - offset).max(0.0);
+
+    // Calculate drawable area
+    let (drawable_width, drawable_height) = match config.cell_dimensions {
+        Some((cw, ch)) => (
+            config.grid_width as f64 * cw,
+            config.grid_height as f64 * ch,
+        ),
+        None => (rect.width() - 2.0 * offset, rect.height() - 2.0 * offset),
+    };
+
+    // Avoid division by zero
+    if drawable_width <= 0.0 || drawable_height <= 0.0 {
+        return (0, 0);
+    }
+
+    // Map to grid coordinates
+    let col = ((relative_x / drawable_width) * config.grid_width as f64) as u16;
+    let row = ((relative_y / drawable_height) * config.grid_height as f64) as u16;
+
+    // Clamp to bounds
+    (
+        col.min(config.grid_width.saturating_sub(1)),
+        row.min(config.grid_height.saturating_sub(1)),
+    )
+}
+
+/// Converts a web_sys::MouseEvent type string to a MouseEventKind.
+pub(super) fn event_type_to_kind(event_type: &str, button: MouseButton) -> MouseEventKind {
+    match event_type {
+        "mousemove" => MouseEventKind::Moved,
+        "mousedown" => MouseEventKind::ButtonDown(button),
+        "mouseup" => MouseEventKind::ButtonUp(button),
+        "click" => MouseEventKind::SingleClick(button),
+        "dblclick" => MouseEventKind::DoubleClick(button),
+        "mouseenter" => MouseEventKind::Entered,
+        "mouseleave" => MouseEventKind::Exited,
+        _ => MouseEventKind::Unidentified,
+    }
+}
+
+/// Creates a MouseEvent from web_sys events with coordinate translation.
+pub(super) fn create_mouse_event(
+    event: &web_sys::MouseEvent,
+    element: &Element,
+    config: &MouseConfig,
+) -> MouseEvent {
+    let (col, row) = mouse_to_grid_coords(event, element, config);
+    let button: MouseButton = event.button().into();
+    let event_type = event.type_();
+
+    MouseEvent {
+        kind: event_type_to_kind(&event_type, button),
+        col,
+        row,
+        ctrl: event.ctrl_key(),
+        alt: event.alt_key(),
+        shift: event.shift_key(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mouse_config_builder() {
+        let config = MouseConfig::new(80, 24)
+            .with_offset(5.0)
+            .with_cell_dimensions(10.0, 19.0);
+
+        assert_eq!(config.grid_width, 80);
+        assert_eq!(config.grid_height, 24);
+        assert_eq!(config.offset, Some(5.0));
+        assert_eq!(config.cell_dimensions, Some((10.0, 19.0)));
+    }
+}

--- a/src/backend/event_callback.rs
+++ b/src/backend/event_callback.rs
@@ -134,7 +134,7 @@ pub(super) const MOUSE_EVENT_TYPES: &[&str] = &[
 ///
 /// This function calculates the grid position (col, row) from raw pixel
 /// coordinates, taking into account element positioning and optional offsets.
-pub(super) fn mouse_to_grid_coords(
+fn mouse_to_grid_coords(
     event: &web_sys::MouseEvent,
     element: &Element,
     config: &MouseConfig,
@@ -172,7 +172,7 @@ pub(super) fn mouse_to_grid_coords(
 }
 
 /// Converts a web_sys::MouseEvent type string to a MouseEventKind.
-pub(super) fn event_type_to_kind(event_type: &str, button: MouseButton) -> MouseEventKind {
+fn event_type_to_kind(event_type: &str, button: MouseButton) -> MouseEventKind {
     match event_type {
         "mousemove" => MouseEventKind::Moved,
         "mousedown" => MouseEventKind::ButtonDown(button),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,6 +30,7 @@
 //! | **Underline**                | ✓          | ✗             | ✓              |
 //! | **Strikethrough**            | ✓          | ✗             | ✓              |
 //! | **Browser Support**          | All        | All           | Modern (2017+) |
+//! | **Mouse Events**             | Full       | Full          | Basic          |
 //!
 //! ¹: The [dynamic font atlas](webgl2::FontAtlasConfig::Dynamic) rasterizes
 //!    glyphs on demand with full Unicode/emoji and font variant support. The
@@ -37,6 +38,22 @@
 //!    compiled into the `.atlas` file.
 //! ²: Unicode is supported, but emoji only render correctly when it spans one cell.
 //!    Most emoji occupy two cells.
+//!
+//! ### Mouse Event Support
+//!
+//! All backends support [`WebEventHandler`] for mouse events with grid coordinate translation.
+//!
+//! | Event Type      | DomBackend | CanvasBackend | WebGl2Backend |
+//! |-----------------|------------|---------------|---------------|
+//! | `Moved`         | ✓          | ✓             | ✓             |
+//! | `ButtonDown`    | ✓          | ✓             | ✓             |
+//! | `ButtonUp`      | ✓          | ✓             | ✓             |
+//! | `SingleClick`   | ✓          | ✓             | ✗             |
+//! | `DoubleClick`   | ✓          | ✓             | ✗             |
+//! | `Entered`       | ✓          | ✓             | ✗             |
+//! | `Exited`        | ✓          | ✓             | ✗             |
+//!
+//! [`WebEventHandler`]: crate::WebEventHandler
 //!
 //! ## Choosing a Backend
 //!
@@ -55,6 +72,8 @@ pub mod webgl2;
 
 /// Color handling.
 mod color;
+/// Event callback management.
+pub(super) mod event_callback;
 /// Backend utilities.
 pub(crate) mod utils;
 

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -853,25 +853,20 @@ impl std::fmt::Debug for HyperlinkCallback {
 /// Event handling for [`WebGl2Backend`].
 ///
 /// This implementation delegates mouse events to beamterm's [`TerminalMouseHandler`],
-/// which provides native grid coordinate translation. However, beamterm only supports
-/// a subset of mouse events:
+/// which provides native grid coordinate translation.
 ///
 /// | Supported | Event Type                      |
 /// | --------- | ------------------------------- |
 /// | ✓         | [`MouseEventKind::Moved`]       |
 /// | ✓         | [`MouseEventKind::ButtonDown`]  |
 /// | ✓         | [`MouseEventKind::ButtonUp`]    |
-/// | ✗         | [`MouseEventKind::SingleClick`] |
+/// | ✓         | [`MouseEventKind::SingleClick`] |
 /// | ✗         | [`MouseEventKind::DoubleClick`] |
-/// | ✗         | [`MouseEventKind::Entered`]     |
-/// | ✗         | [`MouseEventKind::Exited`]      |
-///
-/// For full mouse event support, consider using [`CanvasBackend`] or [`DomBackend`].
+/// | ✓         | [`MouseEventKind::Entered`]     |
+/// | ✓         | [`MouseEventKind::Exited`]      |
 ///
 /// Keyboard events are supported by making the canvas focusable with `tabindex="0"`.
 ///
-/// [`CanvasBackend`]: crate::CanvasBackend
-/// [`DomBackend`]: crate::DomBackend
 /// [`MouseEventKind::Moved`]: crate::event::MouseEventKind::Moved
 /// [`MouseEventKind::ButtonDown`]: crate::event::MouseEventKind::ButtonDown
 /// [`MouseEventKind::ButtonUp`]: crate::event::MouseEventKind::ButtonUp
@@ -952,20 +947,15 @@ impl From<&TerminalMouseEvent> for MouseEvent {
     fn from(event: &TerminalMouseEvent) -> Self {
         use crate::event::{MouseButton, MouseEventKind};
 
-        let button = match event.button() {
-            0 => MouseButton::Left,
-            1 => MouseButton::Middle,
-            2 => MouseButton::Right,
-            3 => MouseButton::Back,
-            4 => MouseButton::Forward,
-            _ => MouseButton::Unidentified,
-        };
+        let button = MouseButton::from(event.button());
 
-        // beamterm only provides MouseMove, MouseDown, and MouseUp events
         let kind = match event.event_type {
             MouseEventType::MouseMove => MouseEventKind::Moved,
             MouseEventType::MouseDown => MouseEventKind::ButtonDown(button),
             MouseEventType::MouseUp => MouseEventKind::ButtonUp(button),
+            MouseEventType::Click => MouseEventKind::SingleClick(button),
+            MouseEventType::MouseEnter => MouseEventKind::Entered,
+            MouseEventType::MouseLeave => MouseEventKind::Exited,
         };
 
         MouseEvent {

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -870,7 +870,7 @@ impl WebEventHandler for WebGl2Backend {
             canvas,
             grid,
             move |event: TerminalMouseEvent, _grid: &beamterm_renderer::TerminalGrid| {
-                let mouse_event = beamterm_event_to_mouse_event(&event);
+                let mouse_event = MouseEvent::from(&event);
                 if let Ok(mut cb) = callback_clone.try_borrow_mut() {
                     cb(mouse_event);
                 }
@@ -915,33 +915,34 @@ impl WebEventHandler for WebGl2Backend {
     }
 }
 
-/// Converts a beamterm `TerminalMouseEvent` to our `MouseEvent` type.
-fn beamterm_event_to_mouse_event(event: &TerminalMouseEvent) -> MouseEvent {
-    use crate::event::{MouseButton, MouseEventKind};
+impl From<&TerminalMouseEvent> for MouseEvent {
+    fn from(event: &TerminalMouseEvent) -> Self {
+        use crate::event::{MouseButton, MouseEventKind};
 
-    let button = match event.button() {
-        0 => MouseButton::Left,
-        1 => MouseButton::Middle,
-        2 => MouseButton::Right,
-        3 => MouseButton::Back,
-        4 => MouseButton::Forward,
-        _ => MouseButton::Unidentified,
-    };
+        let button = match event.button() {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            3 => MouseButton::Back,
+            4 => MouseButton::Forward,
+            _ => MouseButton::Unidentified,
+        };
 
-    // beamterm only provides MouseMove, MouseDown, and MouseUp events
-    let kind = match event.event_type {
-        MouseEventType::MouseMove => MouseEventKind::Moved,
-        MouseEventType::MouseDown => MouseEventKind::ButtonDown(button),
-        MouseEventType::MouseUp => MouseEventKind::ButtonUp(button),
-    };
+        // beamterm only provides MouseMove, MouseDown, and MouseUp events
+        let kind = match event.event_type {
+            MouseEventType::MouseMove => MouseEventKind::Moved,
+            MouseEventType::MouseDown => MouseEventKind::ButtonDown(button),
+            MouseEventType::MouseUp => MouseEventKind::ButtonUp(button),
+        };
 
-    MouseEvent {
-        kind,
-        col: event.col,
-        row: event.row,
-        ctrl: event.ctrl_key(),
-        alt: event.alt_key(),
-        shift: event.shift_key(),
+        MouseEvent {
+            kind,
+            col: event.col,
+            row: event.row,
+            ctrl: event.ctrl_key(),
+            alt: event.alt_key(),
+            shift: event.shift_key(),
+        }
     }
 }
 

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -827,15 +827,15 @@ impl std::fmt::Debug for HyperlinkCallback {
 /// which provides native grid coordinate translation. However, beamterm only supports
 /// a subset of mouse events:
 ///
-/// | Supported | Event Type |
-/// |-----------|------------|
-/// | ✓ | [`MouseEventKind::Moved`] |
-/// | ✓ | [`MouseEventKind::ButtonDown`] |
-/// | ✓ | [`MouseEventKind::ButtonUp`] |
-/// | ✗ | [`MouseEventKind::SingleClick`] |
-/// | ✗ | [`MouseEventKind::DoubleClick`] |
-/// | ✗ | [`MouseEventKind::Entered`] |
-/// | ✗ | [`MouseEventKind::Exited`] |
+/// | Supported | Event Type                      |
+/// | --------- | ------------------------------- |
+/// | ✓         | [`MouseEventKind::Moved`]       |
+/// | ✓         | [`MouseEventKind::ButtonDown`]  |
+/// | ✓         | [`MouseEventKind::ButtonUp`]    |
+/// | ✗         | [`MouseEventKind::SingleClick`] |
+/// | ✗         | [`MouseEventKind::DoubleClick`] |
+/// | ✗         | [`MouseEventKind::Entered`]     |
+/// | ✗         | [`MouseEventKind::Exited`]      |
 ///
 /// For full mouse event support, consider using [`CanvasBackend`] or [`DomBackend`].
 ///

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,17 +11,19 @@ pub struct KeyEvent {
     pub shift: bool,
 }
 
-/// A mouse movement event.
+/// A mouse event with terminal grid coordinates.
+///
+/// Coordinates are reported as terminal cell positions (`col`, `row`),
+/// not raw pixel coordinates. The origin (0, 0) is the top-left cell
+/// of the terminal grid.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct MouseEvent {
-    /// The mouse button that was pressed.
-    pub button: MouseButton,
-    /// The triggered event.
-    pub event: MouseEventKind,
-    /// The x coordinate of the mouse.
-    pub x: u32,
-    /// The y coordinate of the mouse.
-    pub y: u32,
+    /// The type of mouse event that occurred.
+    pub kind: MouseEventKind,
+    /// The column (x-coordinate) in the terminal grid.
+    pub col: u16,
+    /// The row (y-coordinate) in the terminal grid.
+    pub row: u16,
     /// Whether the control key is pressed.
     pub ctrl: bool,
     /// Whether the alt key is pressed.
@@ -126,7 +128,7 @@ impl From<web_sys::KeyboardEvent> for KeyCode {
 }
 
 /// A mouse button.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MouseButton {
     /// Left mouse button
     Left,
@@ -142,41 +144,25 @@ pub enum MouseButton {
     Unidentified,
 }
 
-/// A mouse event.
-#[derive(Debug, Clone, Eq, PartialEq)]
+/// The type of mouse event that occurred.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MouseEventKind {
-    /// Mouse moved
+    /// Mouse cursor moved.
     Moved,
-    /// Mouse button pressed
-    Pressed,
-    /// Mouse button released
-    Released,
-    /// Unidentified mouse event
+    /// Mouse button was pressed down.
+    ButtonDown(MouseButton),
+    /// Mouse button was released.
+    ButtonUp(MouseButton),
+    /// Mouse button was clicked (pressed and released).
+    SingleClick(MouseButton),
+    /// Mouse button was double-clicked.
+    DoubleClick(MouseButton),
+    /// Mouse cursor entered the terminal area.
+    Entered,
+    /// Mouse cursor left the terminal area.
+    Exited,
+    /// Unidentified mouse event.
     Unidentified,
-}
-
-/// Convert a [`web_sys::MouseEvent`] to a [`MouseEvent`].
-impl From<web_sys::MouseEvent> for MouseEvent {
-    fn from(event: web_sys::MouseEvent) -> Self {
-        let ctrl = event.ctrl_key();
-        let alt = event.alt_key();
-        let shift = event.shift_key();
-        let event_type = event.type_().into();
-        MouseEvent {
-            // Button is only valid if it is a mousedown or mouseup event.
-            button: if event_type == MouseEventKind::Moved {
-                MouseButton::Unidentified
-            } else {
-                event.button().into()
-            },
-            event: event_type,
-            x: event.client_x() as u32,
-            y: event.client_y() as u32,
-            ctrl,
-            alt,
-            shift,
-        }
-    }
 }
 
 /// Convert a [`web_sys::MouseEvent`] to a [`MouseButton`].
@@ -189,19 +175,6 @@ impl From<i16> for MouseButton {
             3 => MouseButton::Back,
             4 => MouseButton::Forward,
             _ => MouseButton::Unidentified,
-        }
-    }
-}
-
-/// Convert a [`web_sys::MouseEvent`] to a [`MouseEventKind`].
-impl From<String> for MouseEventKind {
-    fn from(event: String) -> Self {
-        let event = event.as_str();
-        match event {
-            "mousemove" => MouseEventKind::Moved,
-            "mousedown" => MouseEventKind::Pressed,
-            "mouseup" => MouseEventKind::Released,
-            _ => MouseEventKind::Unidentified,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub use backend::{
     dom::DomBackend,
     webgl2::{FontAtlasConfig, SelectionMode, WebGl2Backend},
 };
-pub use render::WebRenderer;
+pub use render::{WebEventHandler, WebRenderer};

--- a/src/render.rs
+++ b/src/render.rs
@@ -111,13 +111,13 @@ where
 /// use ratzilla::{CanvasBackend, WebRenderer};
 /// use ratatui::Terminal;
 ///
-/// let mut terminal = Terminal::new(CanvasBackend::new().unwrap()).unwrap();
+/// let mut terminal = Terminal::new(CanvasBackend::new()?)?;
 ///
 /// // Set up mouse events with grid coordinate translation
 /// terminal.on_mouse_event(|event| {
 ///     // event.col and event.row are terminal grid coordinates
 ///     println!("Mouse at ({}, {})", event.col, event.row);
-/// }).unwrap();
+/// })?;
 /// ```
 pub trait WebEventHandler {
     /// Sets up mouse event handlers with coordinate translation.

--- a/src/render.rs
+++ b/src/render.rs
@@ -108,6 +108,7 @@ where
 /// # Example
 ///
 /// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use ratzilla::{CanvasBackend, WebRenderer};
 /// use ratatui::Terminal;
 ///
@@ -118,6 +119,8 @@ where
 ///     // event.col and event.row are terminal grid coordinates
 ///     println!("Mouse at ({}, {})", event.col, event.row);
 /// })?;
+/// # Ok(())
+/// # }
 /// ```
 pub trait WebEventHandler {
     /// Sets up mouse event handlers with coordinate translation.

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,19 +2,20 @@ use ratatui::{prelude::Backend, Frame, Terminal};
 use std::{cell::RefCell, rc::Rc};
 use web_sys::{wasm_bindgen::prelude::*, window};
 
-use crate::event::{KeyEvent, MouseEvent};
+use crate::{
+    error::Error,
+    event::{KeyEvent, MouseEvent},
+};
 
 /// Trait for rendering on the web.
 ///
 /// It provides all the necessary methods to render the terminal on the web
-/// and also interact with the browser such as handling key events.
+/// and also interact with the browser such as handling key and mouse events.
 pub trait WebRenderer {
     /// Renders the terminal on the web.
     ///
     /// This method takes a closure that will be called on every update
     /// that the browser makes during [`requestAnimationFrame`] calls.
-    ///
-    /// TODO: Clarify and validate this.
     ///
     /// [`requestAnimationFrame`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame
     fn draw_web<F>(self, render_callback: F)
@@ -23,47 +24,28 @@ pub trait WebRenderer {
 
     /// Handles key events.
     ///
-    /// This method takes a closure that will be called on every `keydown`
-    /// event.
-    fn on_key_event<F>(&self, mut callback: F)
+    /// This method takes a closure that will be called on every `keydown` event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend does not support key events or if
+    /// event listener attachment fails.
+    fn on_key_event<F>(&mut self, callback: F) -> Result<(), Error>
     where
-        F: FnMut(KeyEvent) + 'static,
-    {
-        let closure = Closure::<dyn FnMut(_)>::new(move |event: web_sys::KeyboardEvent| {
-            callback(event.into());
-        });
-        let window = window().unwrap();
-        let document = window.document().unwrap();
-        document
-            .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
-            .unwrap();
-        closure.forget();
-    }
+        F: FnMut(KeyEvent) + 'static;
 
     /// Handles mouse events.
     ///
-    /// This method takes a closure that will be called on every `mousemove`, 'mousedown', and `mouseup`
-    /// event.
-    fn on_mouse_event<F>(&self, mut callback: F)
+    /// This method takes a closure that will be called on mouse events.
+    /// The callback receives [`MouseEvent`]s with terminal grid coordinates
+    /// (`col`, `row`) instead of raw pixel coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if event listener attachment fails.
+    fn on_mouse_event<F>(&mut self, callback: F) -> Result<(), Error>
     where
-        F: FnMut(MouseEvent) + 'static,
-    {
-        let closure = Closure::<dyn FnMut(_)>::new(move |event: web_sys::MouseEvent| {
-            callback(event.into());
-        });
-        let window = window().unwrap();
-        let document = window.document().unwrap();
-        document
-            .add_event_listener_with_callback("mousemove", closure.as_ref().unchecked_ref())
-            .unwrap();
-        document
-            .add_event_listener_with_callback("mousedown", closure.as_ref().unchecked_ref())
-            .unwrap();
-        document
-            .add_event_listener_with_callback("mouseup", closure.as_ref().unchecked_ref())
-            .unwrap();
-        closure.forget();
-    }
+        F: FnMut(MouseEvent) + 'static;
 
     /// Requests an animation frame.
     fn request_animation_frame(f: &Closure<dyn FnMut()>) {
@@ -76,10 +58,11 @@ pub trait WebRenderer {
 
 /// Implement [`WebRenderer`] for Ratatui's [`Terminal`].
 ///
-/// This implementation creates a loop that calls the [`Terminal::draw`] method.
+/// This implementation delegates event handling to the backend's
+/// [`WebEventHandler`] implementation.
 impl<T> WebRenderer for Terminal<T>
 where
-    T: Backend + 'static,
+    T: Backend + WebEventHandler + 'static,
 {
     fn draw_web<F>(mut self, mut render_callback: F)
     where
@@ -98,4 +81,88 @@ where
         }) as Box<dyn FnMut()>));
         Self::request_animation_frame(callback.borrow().as_ref().unwrap());
     }
+
+    fn on_key_event<F>(&mut self, callback: F) -> Result<(), Error>
+    where
+        F: FnMut(KeyEvent) + 'static,
+    {
+        self.backend_mut().on_key_event(callback)
+    }
+
+    fn on_mouse_event<F>(&mut self, callback: F) -> Result<(), Error>
+    where
+        F: FnMut(MouseEvent) + 'static,
+    {
+        self.backend_mut().on_mouse_event(callback)
+    }
+}
+
+/// Backend-specific event handling with lifecycle management.
+///
+/// This trait provides proper event handling for terminal backends, including:
+/// - Coordinate translation from pixels to terminal grid positions
+/// - Automatic cleanup of event listeners when replaced or dropped
+/// - Extended mouse event support (enter/leave, click/dblclick)
+///
+/// # Example
+///
+/// ```no_run
+/// use ratzilla::{CanvasBackend, WebRenderer};
+/// use ratatui::Terminal;
+///
+/// let mut terminal = Terminal::new(CanvasBackend::new().unwrap()).unwrap();
+///
+/// // Set up mouse events with grid coordinate translation
+/// terminal.on_mouse_event(|event| {
+///     // event.col and event.row are terminal grid coordinates
+///     println!("Mouse at ({}, {})", event.col, event.row);
+/// }).unwrap();
+/// ```
+pub trait WebEventHandler {
+    /// Sets up mouse event handlers with coordinate translation.
+    ///
+    /// The callback receives [`MouseEvent`]s with terminal grid coordinates
+    /// (`col`, `row`) instead of raw pixel coordinates. Coordinates are
+    /// relative to the terminal element, not the viewport.
+    ///
+    /// Calling this method again will automatically clean up the previous
+    /// event listeners before setting up new ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if event listener attachment fails.
+    fn on_mouse_event<F>(&mut self, callback: F) -> Result<(), Error>
+    where
+        F: FnMut(MouseEvent) + 'static;
+
+    /// Removes all mouse event handlers.
+    ///
+    /// This is automatically called when new handlers are set up, but can be
+    /// called manually to stop receiving mouse events.
+    fn clear_mouse_events(&mut self);
+
+    /// Sets up keyboard event handlers.
+    ///
+    /// The callback receives [`KeyEvent`]s for `keydown` events.
+    ///
+    /// Calling this method again will automatically clean up the previous
+    /// event listeners before setting up new ones.
+    ///
+    /// **Note**: Some backends (e.g., [`WebGl2Backend`]) do not support key events
+    /// and will silently succeed without registering any handlers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if event listener attachment fails.
+    ///
+    /// [`WebGl2Backend`]: crate::WebGl2Backend
+    fn on_key_event<F>(&mut self, callback: F) -> Result<(), Error>
+    where
+        F: FnMut(KeyEvent) + 'static;
+
+    /// Removes all keyboard event handlers.
+    ///
+    /// This is automatically called when new handlers are set up, but can be
+    /// called manually to stop receiving key events.
+    fn clear_key_events(&mut self);
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -100,6 +100,7 @@ where
 /// Backend-specific event handling with lifecycle management.
 ///
 /// This trait provides proper event handling for terminal backends, including:
+///
 /// - Coordinate translation from pixels to terminal grid positions
 /// - Automatic cleanup of event listeners when replaced or dropped
 /// - Extended mouse event support (enter/leave, click/dblclick)

--- a/src/render.rs
+++ b/src/render.rs
@@ -149,7 +149,9 @@ pub trait WebEventHandler {
     /// Calling this method again will automatically clean up the previous
     /// event listeners before setting up new ones.
     ///
-    /// **Note**: Some backends (e.g., [`WebGl2Backend`]) do not support key events
+    /// # Note
+    ///
+    ///  Some backends (e.g., [`WebGl2Backend`]) do not support key events
     /// and will silently succeed without registering any handlers.
     ///
     /// # Errors


### PR DESCRIPTION
Mouse events now report **grid coordinates** (col, row) instead of pixel coordinates, and event registration has been unified through the terminal API with proper lifecycle management.

### Key Changes

- **Grid coordinates**: `MouseEvent` now has `col`/`row` fields for terminal cell positions
- **Unified API**: Event registration moved from backend options to `terminal.on_mouse_event()` / `terminal.on_key_event()`
- **Lifecycle management**: Event callbacks are properly cleaned up and replaced to prevent memory leaks
- **Callback replacement**: Registering a new callback automatically clears the previous one

### Usage

```rust
// mut due to later holding onto the callbacks/closures
let mut terminal = MultiBackendBuilder::with_fallback(BackendType::Dom)
  .build_terminal()?;

terminal.on_mouse_event(|mouse_event| {
  println!("{:?} at cell: ({}, {})", mouse_event.kind, mouse_event.col, mouse_event.row);
}).ok(); // WebGL2 doesn't support mouse events yet

// This replaces any previous key event callback
terminal.on_key_event(|key_event| {
  println!("Key: {:?}", key_event.code);
}).ok();
```

### Mouse Event Types

Available `MouseEventKind` variants: 
- `Moved` - mouse move event
- `ButtonDown(MouseButton)` - button pressed
- `ButtonUp(MouseButton)` - button released
- `Entered` - mouse entered terminal area
- `Exited` - mouse left terminal area
- `SingleClick(MouseButton)` - single click (down + up)
- `DoubleClick(MouseButton),` - single click x2 in quick succession


### Breaking Changes

- Mouse coordinates changed from pixels to grid cells
- Event registration: backend_options.mouse_event_handler() → terminal.on_mouse_event()
- Terminal must be `mut` for event registration
  - Both mouse and key callbacks are now lifecycle managed (prevents leaks, replaces previous callbacks)
