### PR TITLE
Allow canvas backend to resize dynamically

### DIFF
--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -10,5 +10,4 @@ ratzilla.workspace = true
 tachyonfx.workspace = true
 web-time.workspace = true
 examples-shared.workspace = true
-console_error_panic_hook.workspace = true
 # tui-big-text = "0.6.1"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -10,4 +10,5 @@ ratzilla.workspace = true
 tachyonfx.workspace = true
 web-time.workspace = true
 examples-shared.workspace = true
+console_error_panic_hook.workspace = true
 # tui-big-text = "0.6.1"

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -10,9 +10,9 @@ use std::{cell::RefCell, io::Result, rc::Rc};
 
 use app::App;
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
+use ratzilla::WebRenderer;
 use ratzilla::backend::webgl2::WebGl2BackendOptions;
 use ratzilla::event::KeyCode;
-use ratzilla::WebRenderer;
 
 mod app;
 
@@ -20,7 +20,6 @@ mod effects;
 mod ui;
 
 fn main() -> Result<()> {
-    console_error_panic_hook::set_once();
     let app_state = Rc::new(RefCell::new(App::new("Demo", true)));
 
     let webgl2_options = WebGl2BackendOptions::new()

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -10,9 +10,9 @@ use std::{cell::RefCell, io::Result, rc::Rc};
 
 use app::App;
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
+use ratzilla::backend::webgl2::WebGl2BackendOptions;
 use ratzilla::event::KeyCode;
 use ratzilla::WebRenderer;
-use ratzilla::backend::webgl2::WebGl2BackendOptions;
 
 mod app;
 
@@ -20,6 +20,7 @@ mod effects;
 mod ui;
 
 fn main() -> Result<()> {
+    console_error_panic_hook::set_once();
     let app_state = Rc::new(RefCell::new(App::new("Demo", true)));
 
     let webgl2_options = WebGl2BackendOptions::new()

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -28,7 +28,7 @@ use ratatui::{
 };
 use web_sys::{
     js_sys::{Boolean, Map},
-    wasm_bindgen::{prelude::Closure, JsCast, JsValue},
+    wasm_bindgen::{JsCast, JsValue},
 };
 
 /// Width of a single cell.
@@ -203,6 +203,8 @@ pub struct CanvasBackend {
     mouse_callback: Option<MouseCallbackState>,
     /// Key event callback handler.
     key_callback: Option<EventCallback<web_sys::KeyboardEvent>>,
+    /// Resize event callback handler
+    resize_callback: EventCallback<web_sys::Event>,
 }
 
 /// Type alias for mouse event callback state.
@@ -232,16 +234,16 @@ impl CanvasBackend {
 
         let initialized = Rc::new(AtomicBool::new(false));
 
-        let closure = Closure::<dyn FnMut(_)>::new({
-            let initialized = Rc::clone(&initialized);
-            move |_: web_sys::Event| {
-                initialized.store(false, Ordering::Relaxed);
-            }
-        });
-        web_sys::window()
-            .unwrap()
-            .set_onresize(Some(closure.as_ref().unchecked_ref()));
-        closure.forget();
+        let resize_callback = EventCallback::new(
+            web_sys::window().ok_or(Error::UnableToRetrieveWindow)?,
+            &["resize"],
+            {
+                let initialized = Rc::clone(&initialized);
+                move |_: web_sys::Event| {
+                    initialized.store(false, Ordering::Relaxed);
+                }
+            },
+        )?;
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
@@ -257,6 +259,7 @@ impl CanvasBackend {
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,
+            resize_callback,
         })
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -82,7 +82,7 @@ struct Canvas {
     /// Canvas element.
     inner: web_sys::HtmlCanvasElement,
     /// Canvas parent element.
-    parent: web_sys::Element,
+    parent: Option<web_sys::Element>,
     /// Rendering context.
     context: web_sys::CanvasRenderingContext2d,
     /// Background color.
@@ -94,18 +94,33 @@ struct Canvas {
 impl Canvas {
     /// Constructs a new [`Canvas`].
     fn new(
-        parent_element: web_sys::Element,
+        parent_element: Option<web_sys::Element>,
         size: Option<(u32, u32)>,
         background_color: Color,
     ) -> Result<Self, Error> {
-        let (width, height) = size.unwrap_or_else(|| {
-            (
-                parent_element.client_width() as u32,
-                parent_element.client_height() as u32,
-            )
-        });
+        let (width, height) = size
+            .or_else(|| {
+                parent_element
+                    .as_ref()
+                    .map(|p| (p.client_width() as u32, p.client_height() as u32))
+            })
+            .unwrap_or_else(|| {
+                let (width, height) = get_raw_window_size();
+                (width as u32, height as u32)
+            });
 
-        let canvas = create_canvas_in_element(&parent_element, width, height)?;
+        let canvas = if let Some(element) = parent_element.as_ref() {
+            create_canvas_in_element(element, width, height)?
+        } else {
+            create_canvas_in_element(
+                &get_document()?
+                    .body()
+                    .ok_or(Error::UnableToRetrieveBody)?
+                    .into(),
+                width,
+                height,
+            )?
+        };
 
         let context_options = Map::new();
         context_options.set(&JsValue::from_str("alpha"), &Boolean::from(JsValue::TRUE));
@@ -130,12 +145,17 @@ impl Canvas {
 
     /// Returns true if the size changed
     fn init_ctx_and_resize(&self) -> Result<Option<(usize, usize)>, Error> {
-        let (width, height) = self.size.unwrap_or_else(|| {
-            (
-                self.parent.client_width() as u32,
-                self.parent.client_height() as u32,
-            )
-        });
+        let (width, height) = self
+            .size
+            .or_else(|| {
+                self.parent
+                    .as_ref()
+                    .map(|p| (p.client_width() as u32, p.client_height() as u32))
+            })
+            .unwrap_or_else(|| {
+                let (width, height) = get_raw_window_size();
+                (width as u32, height as u32)
+            });
 
         let ratio = web_sys::window()
             .ok_or(Error::UnableToRetrieveWindow)?
@@ -224,7 +244,11 @@ impl CanvasBackend {
     /// Constructs a new [`CanvasBackend`] with the given options.
     pub fn new_with_options(options: CanvasBackendOptions) -> Result<Self, Error> {
         // Parent element of canvas (uses <body> unless specified)
-        let parent = get_element_by_id_or_body(options.grid_id.as_ref())?;
+        let parent = if let Some(id) = options.grid_id.as_ref() {
+            Some(get_element_by_id_or_body(Some(id))?)
+        } else {
+            None
+        };
 
         let canvas = Canvas::new(parent, options.size, Color::Black)?;
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -3,7 +3,7 @@ use ratatui::{backend::ClearType, layout::Rect};
 use std::{
     io::{Error as IoError, Result as IoResult},
     rc::Rc,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU16, Ordering},
 };
 
 use crate::{
@@ -201,6 +201,8 @@ pub struct CanvasBackend {
     /// this option may cause some performance issues when dealing with large
     /// numbers of simultaneous changes.
     always_clip_cells: bool,
+    /// The size of the buffer in cells
+    grid_size: Rc<(AtomicU16, AtomicU16)>,
     /// Current buffer.
     buffer: Vec<Vec<Cell>>,
     /// Previous buffer.
@@ -267,10 +269,15 @@ impl CanvasBackend {
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
+        let buffer_size = Rc::new((
+            AtomicU16::new(buffer[0].len() as u16),
+            AtomicU16::new(buffer.len() as u16),
+        ));
         Ok(Self {
             prev_buffer: buffer.clone(),
             always_clip_cells: options.always_clip_cells,
             buffer,
+            grid_size: buffer_size,
             initialized,
             changed_cells,
             canvas,
@@ -579,6 +586,12 @@ impl Backend for CanvasBackend {
                 }
                 self.changed_cells
                     .resize(new_buffer_size.0 * new_buffer_size.1, true);
+                self.grid_size
+                    .0
+                    .store(new_buffer_size.0 as u16, Ordering::Relaxed);
+                self.grid_size
+                    .1
+                    .store(new_buffer_size.1 as u16, Ordering::Relaxed);
             }
             self.update_grid(true)?;
             self.prev_buffer = self.buffer.clone();
@@ -630,8 +643,8 @@ impl Backend for CanvasBackend {
 
     fn size(&self) -> IoResult<Size> {
         Ok(Size::new(
-            self.buffer[0].len() as u16,
-            self.buffer.len() as u16,
+            self.grid_size.0.load(Ordering::Relaxed),
+            self.grid_size.1.load(Ordering::Relaxed),
         ))
     }
 
@@ -677,27 +690,22 @@ impl WebEventHandler for CanvasBackend {
         // Clear any existing handlers first
         self.clear_mouse_events();
 
-        // Get grid dimensions from the buffer
-        let grid_width = self.buffer[0].len() as u16;
-        let grid_height = self.buffer.len() as u16;
-
-        // Configure coordinate translation for canvas backend
-        let config = MouseConfig::new(grid_width, grid_height)
-            .with_offset(5.0) // Canvas translation offset
-            .with_cell_dimensions(CELL_WIDTH, CELL_HEIGHT);
-
         let element: web_sys::Element = self.canvas.inner.clone().into();
         let element_for_closure = element.clone();
 
         // Create mouse event callback
-        let mouse_callback = EventCallback::new(
-            element,
-            MOUSE_EVENT_TYPES,
+        let mouse_callback = EventCallback::new(element, MOUSE_EVENT_TYPES, {
+            let grid_size = Rc::clone(&self.grid_size);
             move |event: web_sys::MouseEvent| {
+                let config = MouseConfig::new(
+                    grid_size.0.load(Ordering::Relaxed),
+                    grid_size.1.load(Ordering::Relaxed),
+                )
+                .with_cell_dimensions(CELL_WIDTH, CELL_HEIGHT);
                 let mouse_event = create_mouse_event(&event, &element_for_closure, &config);
                 callback(mouse_event);
-            },
-        )?;
+            }
+        })?;
 
         self.mouse_callback = Some(mouse_callback);
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -155,18 +155,14 @@ impl Canvas {
             self.inner.set_height((canvas_h * ratio) as u32);
             self.inner
                 .style()
-                .set_property("width", &format!("{}px", canvas_w))
-                .map_err(|e| Error::JsValue(e))?;
+                .set_property("width", &format!("{}px", canvas_w))?;
             self.inner
                 .style()
-                .set_property("height", &format!("{}px", canvas_h))
-                .map_err(|e| Error::JsValue(e))?;
+                .set_property("height", &format!("{}px", canvas_h))?;
 
             self.context.set_font("16px monospace");
             self.context.set_text_baseline("top");
-            self.context
-                .scale(ratio, ratio)
-                .map_err(|e| Error::JsValue(e))?;
+            self.context.scale(ratio, ratio)?;
         }
 
         Ok(change_size.then_some((source_w as usize, source_h as usize)))
@@ -204,7 +200,7 @@ pub struct CanvasBackend {
     /// Key event callback handler.
     key_callback: Option<EventCallback<web_sys::KeyboardEvent>>,
     /// Resize event callback handler
-    resize_callback: EventCallback<web_sys::Event>,
+    _resize_callback: EventCallback<web_sys::Event>,
 }
 
 /// Type alias for mouse event callback state.
@@ -259,7 +255,7 @@ impl CanvasBackend {
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,
-            resize_callback,
+            _resize_callback: resize_callback,
         })
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -308,7 +308,6 @@ impl CanvasBackend {
                 self.canvas.inner.client_height() as f64,
             );
         }
-        self.canvas.context.translate(5_f64, 5_f64)?;
 
         // NOTE: The draw_* functions each traverse the buffer once, instead of
         // traversing it once per cell; this is done to reduce the number of
@@ -321,7 +320,6 @@ impl CanvasBackend {
             self.draw_debug()?;
         }
 
-        self.canvas.context.translate(-5_f64, -5_f64)?;
         Ok(())
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -232,18 +232,16 @@ impl CanvasBackend {
 
         let initialized = Rc::new(AtomicBool::new(false));
 
-        if options.size.is_none() {
-            let closure = Closure::<dyn FnMut(_)>::new({
-                let initialized = Rc::clone(&initialized);
-                move |_: web_sys::Event| {
-                    initialized.store(false, Ordering::Relaxed);
-                }
-            });
-            web_sys::window()
-                .unwrap()
-                .set_onresize(Some(closure.as_ref().unchecked_ref()));
-            closure.forget();
-        }
+        let closure = Closure::<dyn FnMut(_)>::new({
+            let initialized = Rc::clone(&initialized);
+            move |_: web_sys::Event| {
+                initialized.store(false, Ordering::Relaxed);
+            }
+        });
+        web_sys::window()
+            .unwrap()
+            .set_onresize(Some(closure.as_ref().unchecked_ref()));
+        closure.forget();
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
@@ -545,7 +543,6 @@ impl Backend for CanvasBackend {
     fn flush(&mut self) -> IoResult<()> {
         // Only runs once.
         if !self.initialized.swap(true, Ordering::Relaxed) {
-            web_sys::console::log_1(&"in not initialized".into());
             if let Some(new_buffer_size) = self.canvas.init_ctx_and_resize()? {
                 self.buffer.resize_with(new_buffer_size.1, || {
                     vec![Cell::default(); new_buffer_size.0]

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -606,8 +606,8 @@ impl Backend for CanvasBackend {
 
     fn size(&self) -> IoResult<Size> {
         Ok(Size::new(
-            self.buffer[0].len().saturating_sub(1) as u16,
-            self.buffer.len().saturating_sub(1) as u16,
+            self.buffer[0].len() as u16,
+            self.buffer.len() as u16,
         ))
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -141,8 +141,8 @@ impl Canvas {
             .ok_or(Error::UnableToRetrieveWindow)?
             .device_pixel_ratio();
 
-        let source_w = (width as f64 / CELL_WIDTH).ceil();
-        let source_h = (height as f64 / CELL_HEIGHT).ceil();
+        let source_w = (width as f64 / CELL_WIDTH).floor();
+        let source_h = (height as f64 / CELL_HEIGHT).floor();
 
         let canvas_w = source_w * CELL_WIDTH;
         let canvas_h = source_h * CELL_HEIGHT;

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -1,6 +1,10 @@
 use bitvec::{bitvec, prelude::BitVec};
 use ratatui::{backend::ClearType, layout::Rect};
-use std::io::{Error as IoError, Result as IoResult};
+use std::{
+    io::{Error as IoError, Result as IoResult},
+    rc::Rc,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::{
     backend::{
@@ -24,7 +28,7 @@ use ratatui::{
 };
 use web_sys::{
     js_sys::{Boolean, Map},
-    wasm_bindgen::{JsCast, JsValue},
+    wasm_bindgen::{prelude::Closure, JsCast, JsValue},
 };
 
 /// Width of a single cell.
@@ -77,20 +81,30 @@ impl CanvasBackendOptions {
 struct Canvas {
     /// Canvas element.
     inner: web_sys::HtmlCanvasElement,
+    /// Canvas parent element.
+    parent: web_sys::Element,
     /// Rendering context.
     context: web_sys::CanvasRenderingContext2d,
     /// Background color.
     background_color: Color,
+    /// If the canvas is a fixed size, that size
+    size: Option<(u32, u32)>,
 }
 
 impl Canvas {
     /// Constructs a new [`Canvas`].
     fn new(
         parent_element: web_sys::Element,
-        width: u32,
-        height: u32,
+        size: Option<(u32, u32)>,
         background_color: Color,
     ) -> Result<Self, Error> {
+        let (width, height) = size.unwrap_or_else(|| {
+            (
+                parent_element.client_width() as u32,
+                parent_element.client_height() as u32,
+            )
+        });
+
         let canvas = create_canvas_in_element(&parent_element, width, height)?;
 
         let context_options = Map::new();
@@ -104,14 +118,58 @@ impl Canvas {
             .ok_or_else(|| Error::UnableToRetrieveCanvasContext)?
             .dyn_into::<web_sys::CanvasRenderingContext2d>()
             .expect("Unable to cast canvas context");
-        context.set_font("16px monospace");
-        context.set_text_baseline("top");
 
         Ok(Self {
             inner: canvas,
+            parent: parent_element,
             context,
             background_color,
+            size,
         })
+    }
+
+    /// Returns true if the size changed
+    fn init_ctx_and_resize(&self) -> Result<Option<(usize, usize)>, Error> {
+        let (width, height) = self.size.unwrap_or_else(|| {
+            (
+                self.parent.client_width() as u32,
+                self.parent.client_height() as u32,
+            )
+        });
+
+        let ratio = web_sys::window()
+            .ok_or(Error::UnableToRetrieveWindow)?
+            .device_pixel_ratio();
+
+        let source_w = (width as f64 / CELL_WIDTH).ceil();
+        let source_h = (height as f64 / CELL_HEIGHT).ceil();
+
+        let canvas_w = source_w * CELL_WIDTH;
+        let canvas_h = source_h * CELL_HEIGHT;
+
+        let change_size = self.inner.width() != (canvas_w * ratio) as u32
+            || self.inner.height() != (canvas_h * ratio) as u32;
+
+        if change_size {
+            self.inner.set_width((canvas_w * ratio) as u32);
+            self.inner.set_height((canvas_h * ratio) as u32);
+            self.inner
+                .style()
+                .set_property("width", &format!("{}px", canvas_w))
+                .map_err(|e| Error::JsValue(e))?;
+            self.inner
+                .style()
+                .set_property("height", &format!("{}px", canvas_h))
+                .map_err(|e| Error::JsValue(e))?;
+
+            self.context.set_font("16px monospace");
+            self.context.set_text_baseline("top");
+            self.context
+                .scale(ratio, ratio)
+                .map_err(|e| Error::JsValue(e))?;
+        }
+
+        Ok(change_size.then_some((source_w as usize, source_h as usize)))
     }
 }
 
@@ -121,7 +179,7 @@ impl Canvas {
 #[derive(Debug)]
 pub struct CanvasBackend {
     /// Whether the canvas has been initialized.
-    initialized: bool,
+    initialized: Rc<AtomicBool>,
     /// Always clip foreground drawing to the cell rectangle. Helpful when
     /// dealing with out-of-bounds rendering from problematic fonts. Enabling
     /// this option may cause some performance issues when dealing with large
@@ -170,18 +228,30 @@ impl CanvasBackend {
         // Parent element of canvas (uses <body> unless specified)
         let parent = get_element_by_id_or_body(options.grid_id.as_ref())?;
 
-        let (width, height) = options
-            .size
-            .unwrap_or_else(|| (parent.client_width() as u32, parent.client_height() as u32));
+        let canvas = Canvas::new(parent, options.size, Color::Black)?;
 
-        let canvas = Canvas::new(parent, width, height, Color::Black)?;
+        let initialized = Rc::new(AtomicBool::new(false));
+
+        if options.size.is_none() {
+            let closure = Closure::<dyn FnMut(_)>::new({
+                let initialized = Rc::clone(&initialized);
+                move |_: web_sys::Event| {
+                    initialized.store(false, Ordering::Relaxed);
+                }
+            });
+            web_sys::window()
+                .unwrap()
+                .set_onresize(Some(closure.as_ref().unchecked_ref()));
+            closure.forget();
+        }
+
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
         Ok(Self {
             prev_buffer: buffer.clone(),
             always_clip_cells: options.always_clip_cells,
             buffer,
-            initialized: false,
+            initialized,
             changed_cells,
             canvas,
             cursor_position: None,
@@ -474,10 +544,26 @@ impl Backend for CanvasBackend {
     /// actually render the content to the screen.
     fn flush(&mut self) -> IoResult<()> {
         // Only runs once.
-        if !self.initialized {
+        if !self.initialized.swap(true, Ordering::Relaxed) {
+            web_sys::console::log_1(&"in not initialized".into());
+            if let Some(new_buffer_size) = self.canvas.init_ctx_and_resize()? {
+                self.buffer.resize_with(new_buffer_size.1, || {
+                    vec![Cell::default(); new_buffer_size.0]
+                });
+                self.prev_buffer.resize_with(new_buffer_size.1, || {
+                    vec![Cell::default(); new_buffer_size.0]
+                });
+                for line in self.buffer.iter_mut() {
+                    line.resize_with(new_buffer_size.0, || Cell::default());
+                }
+                for line in self.prev_buffer.iter_mut() {
+                    line.resize_with(new_buffer_size.0, || Cell::default());
+                }
+                self.changed_cells
+                    .resize(new_buffer_size.0 * new_buffer_size.1, true);
+            }
             self.update_grid(true)?;
             self.prev_buffer = self.buffer.clone();
-            self.initialized = true;
             return Ok(());
         }
 
@@ -517,7 +603,10 @@ impl Backend for CanvasBackend {
     }
 
     fn clear(&mut self) -> IoResult<()> {
-        self.buffer = get_sized_buffer();
+        self.buffer
+            .iter_mut()
+            .flatten()
+            .for_each(|c| *c = Cell::default());
         Ok(())
     }
 


### PR DESCRIPTION
This PR implements resizing for the canvas backend. If the user did not set a fixed size on the canvas, changing the window size will adjust the size of the canvas.