### PR TITLE
Calculate font metrics in Canvas backend

### DIFF
--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -10,5 +10,4 @@ ratzilla.workspace = true
 tachyonfx.workspace = true
 web-time.workspace = true
 examples-shared.workspace = true
-console_error_panic_hook.workspace = true
 # tui-big-text = "0.6.1"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -10,4 +10,5 @@ ratzilla.workspace = true
 tachyonfx.workspace = true
 web-time.workspace = true
 examples-shared.workspace = true
+console_error_panic_hook.workspace = true
 # tui-big-text = "0.6.1"

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -10,9 +10,9 @@ use std::{cell::RefCell, io::Result, rc::Rc};
 
 use app::App;
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
+use ratzilla::WebRenderer;
 use ratzilla::backend::webgl2::WebGl2BackendOptions;
 use ratzilla::event::KeyCode;
-use ratzilla::WebRenderer;
 
 mod app;
 
@@ -20,7 +20,6 @@ mod effects;
 mod ui;
 
 fn main() -> Result<()> {
-    console_error_panic_hook::set_once();
     let app_state = Rc::new(RefCell::new(App::new("Demo", true)));
 
     let webgl2_options = WebGl2BackendOptions::new()

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -10,9 +10,9 @@ use std::{cell::RefCell, io::Result, rc::Rc};
 
 use app::App;
 use examples_shared::backend::{BackendType, MultiBackendBuilder};
+use ratzilla::backend::webgl2::WebGl2BackendOptions;
 use ratzilla::event::KeyCode;
 use ratzilla::WebRenderer;
-use ratzilla::backend::webgl2::WebGl2BackendOptions;
 
 mod app;
 
@@ -20,6 +20,7 @@ mod effects;
 mod ui;
 
 fn main() -> Result<()> {
+    console_error_panic_hook::set_once();
     let app_state = Rc::new(RefCell::new(App::new("Demo", true)));
 
     let webgl2_options = WebGl2BackendOptions::new()

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -28,7 +28,7 @@ use ratatui::{
 };
 use web_sys::{
     js_sys::{Boolean, Map},
-    wasm_bindgen::{prelude::Closure, JsCast, JsValue},
+    wasm_bindgen::{JsCast, JsValue},
 };
 
 /// Width of a single cell.
@@ -203,6 +203,8 @@ pub struct CanvasBackend {
     mouse_callback: Option<MouseCallbackState>,
     /// Key event callback handler.
     key_callback: Option<EventCallback<web_sys::KeyboardEvent>>,
+    /// Resize event callback handler
+    resize_callback: EventCallback<web_sys::Event>,
 }
 
 /// Type alias for mouse event callback state.
@@ -232,16 +234,16 @@ impl CanvasBackend {
 
         let initialized = Rc::new(AtomicBool::new(false));
 
-        let closure = Closure::<dyn FnMut(_)>::new({
-            let initialized = Rc::clone(&initialized);
-            move |_: web_sys::Event| {
-                initialized.store(false, Ordering::Relaxed);
-            }
-        });
-        web_sys::window()
-            .unwrap()
-            .set_onresize(Some(closure.as_ref().unchecked_ref()));
-        closure.forget();
+        let resize_callback = EventCallback::new(
+            web_sys::window().ok_or(Error::UnableToRetrieveWindow)?,
+            &["resize"],
+            {
+                let initialized = Rc::clone(&initialized);
+                move |_: web_sys::Event| {
+                    initialized.store(false, Ordering::Relaxed);
+                }
+            },
+        )?;
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
@@ -257,6 +259,7 @@ impl CanvasBackend {
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,
+            resize_callback,
         })
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -82,7 +82,7 @@ struct Canvas {
     /// Canvas element.
     inner: web_sys::HtmlCanvasElement,
     /// Canvas parent element.
-    parent: web_sys::Element,
+    parent: Option<web_sys::Element>,
     /// Rendering context.
     context: web_sys::CanvasRenderingContext2d,
     /// Background color.
@@ -94,18 +94,33 @@ struct Canvas {
 impl Canvas {
     /// Constructs a new [`Canvas`].
     fn new(
-        parent_element: web_sys::Element,
+        parent_element: Option<web_sys::Element>,
         size: Option<(u32, u32)>,
         background_color: Color,
     ) -> Result<Self, Error> {
-        let (width, height) = size.unwrap_or_else(|| {
-            (
-                parent_element.client_width() as u32,
-                parent_element.client_height() as u32,
-            )
-        });
+        let (width, height) = size
+            .or_else(|| {
+                parent_element
+                    .as_ref()
+                    .map(|p| (p.client_width() as u32, p.client_height() as u32))
+            })
+            .unwrap_or_else(|| {
+                let (width, height) = get_raw_window_size();
+                (width as u32, height as u32)
+            });
 
-        let canvas = create_canvas_in_element(&parent_element, width, height)?;
+        let canvas = if let Some(element) = parent_element.as_ref() {
+            create_canvas_in_element(element, width, height)?
+        } else {
+            create_canvas_in_element(
+                &get_document()?
+                    .body()
+                    .ok_or(Error::UnableToRetrieveBody)?
+                    .into(),
+                width,
+                height,
+            )?
+        };
 
         let context_options = Map::new();
         context_options.set(&JsValue::from_str("alpha"), &Boolean::from(JsValue::TRUE));
@@ -130,12 +145,17 @@ impl Canvas {
 
     /// Returns true if the size changed
     fn init_ctx_and_resize(&self) -> Result<Option<(usize, usize)>, Error> {
-        let (width, height) = self.size.unwrap_or_else(|| {
-            (
-                self.parent.client_width() as u32,
-                self.parent.client_height() as u32,
-            )
-        });
+        let (width, height) = self
+            .size
+            .or_else(|| {
+                self.parent
+                    .as_ref()
+                    .map(|p| (p.client_width() as u32, p.client_height() as u32))
+            })
+            .unwrap_or_else(|| {
+                let (width, height) = get_raw_window_size();
+                (width as u32, height as u32)
+            });
 
         let ratio = web_sys::window()
             .ok_or(Error::UnableToRetrieveWindow)?
@@ -224,7 +244,11 @@ impl CanvasBackend {
     /// Constructs a new [`CanvasBackend`] with the given options.
     pub fn new_with_options(options: CanvasBackendOptions) -> Result<Self, Error> {
         // Parent element of canvas (uses <body> unless specified)
-        let parent = get_element_by_id_or_body(options.grid_id.as_ref())?;
+        let parent = if let Some(id) = options.grid_id.as_ref() {
+            Some(get_element_by_id_or_body(Some(id))?)
+        } else {
+            None
+        };
 
         let canvas = Canvas::new(parent, options.size, Color::Black)?;
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -77,8 +77,11 @@ struct Canvas {
     background_color: Color,
     /// If the canvas is a fixed size, that size
     size: Option<(u32, u32)>,
+    /// The width of a cell
     cell_width: f64,
+    /// The height of a cell
     cell_height: f64,
+    /// The baseline of a font character
     cell_baseline: f64,
 }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -3,7 +3,7 @@ use ratatui::{backend::ClearType, layout::Rect};
 use std::{
     io::{Error as IoError, Result as IoResult},
     rc::Rc,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU16, Ordering},
 };
 
 use crate::{
@@ -201,6 +201,8 @@ pub struct CanvasBackend {
     /// this option may cause some performance issues when dealing with large
     /// numbers of simultaneous changes.
     always_clip_cells: bool,
+    /// The size of the buffer in cells
+    grid_size: Rc<(AtomicU16, AtomicU16)>,
     /// Current buffer.
     buffer: Vec<Vec<Cell>>,
     /// Previous buffer.
@@ -267,10 +269,15 @@ impl CanvasBackend {
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
+        let buffer_size = Rc::new((
+            AtomicU16::new(buffer[0].len() as u16),
+            AtomicU16::new(buffer.len() as u16),
+        ));
         Ok(Self {
             prev_buffer: buffer.clone(),
             always_clip_cells: options.always_clip_cells,
             buffer,
+            grid_size: buffer_size,
             initialized,
             changed_cells,
             canvas,
@@ -579,6 +586,12 @@ impl Backend for CanvasBackend {
                 }
                 self.changed_cells
                     .resize(new_buffer_size.0 * new_buffer_size.1, true);
+                self.grid_size
+                    .0
+                    .store(new_buffer_size.0 as u16, Ordering::Relaxed);
+                self.grid_size
+                    .1
+                    .store(new_buffer_size.1 as u16, Ordering::Relaxed);
             }
             self.update_grid(true)?;
             self.prev_buffer = self.buffer.clone();
@@ -630,8 +643,8 @@ impl Backend for CanvasBackend {
 
     fn size(&self) -> IoResult<Size> {
         Ok(Size::new(
-            self.buffer[0].len() as u16,
-            self.buffer.len() as u16,
+            self.grid_size.0.load(Ordering::Relaxed),
+            self.grid_size.1.load(Ordering::Relaxed),
         ))
     }
 
@@ -677,27 +690,22 @@ impl WebEventHandler for CanvasBackend {
         // Clear any existing handlers first
         self.clear_mouse_events();
 
-        // Get grid dimensions from the buffer
-        let grid_width = self.buffer[0].len() as u16;
-        let grid_height = self.buffer.len() as u16;
-
-        // Configure coordinate translation for canvas backend
-        let config = MouseConfig::new(grid_width, grid_height)
-            .with_offset(5.0) // Canvas translation offset
-            .with_cell_dimensions(CELL_WIDTH, CELL_HEIGHT);
-
         let element: web_sys::Element = self.canvas.inner.clone().into();
         let element_for_closure = element.clone();
 
         // Create mouse event callback
-        let mouse_callback = EventCallback::new(
-            element,
-            MOUSE_EVENT_TYPES,
+        let mouse_callback = EventCallback::new(element, MOUSE_EVENT_TYPES, {
+            let grid_size = Rc::clone(&self.grid_size);
             move |event: web_sys::MouseEvent| {
+                let config = MouseConfig::new(
+                    grid_size.0.load(Ordering::Relaxed),
+                    grid_size.1.load(Ordering::Relaxed),
+                )
+                .with_cell_dimensions(CELL_WIDTH, CELL_HEIGHT);
                 let mouse_event = create_mouse_event(&event, &element_for_closure, &config);
                 callback(mouse_event);
-            },
-        )?;
+            }
+        })?;
 
         self.mouse_callback = Some(mouse_callback);
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -155,18 +155,14 @@ impl Canvas {
             self.inner.set_height((canvas_h * ratio) as u32);
             self.inner
                 .style()
-                .set_property("width", &format!("{}px", canvas_w))
-                .map_err(|e| Error::JsValue(e))?;
+                .set_property("width", &format!("{}px", canvas_w))?;
             self.inner
                 .style()
-                .set_property("height", &format!("{}px", canvas_h))
-                .map_err(|e| Error::JsValue(e))?;
+                .set_property("height", &format!("{}px", canvas_h))?;
 
             self.context.set_font("16px monospace");
             self.context.set_text_baseline("top");
-            self.context
-                .scale(ratio, ratio)
-                .map_err(|e| Error::JsValue(e))?;
+            self.context.scale(ratio, ratio)?;
         }
 
         Ok(change_size.then_some((source_w as usize, source_h as usize)))
@@ -204,7 +200,7 @@ pub struct CanvasBackend {
     /// Key event callback handler.
     key_callback: Option<EventCallback<web_sys::KeyboardEvent>>,
     /// Resize event callback handler
-    resize_callback: EventCallback<web_sys::Event>,
+    _resize_callback: EventCallback<web_sys::Event>,
 }
 
 /// Type alias for mouse event callback state.
@@ -259,7 +255,7 @@ impl CanvasBackend {
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,
-            resize_callback,
+            _resize_callback: resize_callback,
         })
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -31,18 +31,6 @@ use web_sys::{
     wasm_bindgen::{JsCast, JsValue},
 };
 
-/// Width of a single cell.
-///
-/// This will be used for multiplying the cell's x position to get the actual pixel
-/// position on the canvas.
-const CELL_WIDTH: f64 = 10.0;
-
-/// Height of a single cell.
-///
-/// This will be used for multiplying the cell's y position to get the actual pixel
-/// position on the canvas.
-const CELL_HEIGHT: f64 = 19.0;
-
 /// Options for the [`CanvasBackend`].
 #[derive(Debug, Default)]
 pub struct CanvasBackendOptions {
@@ -89,6 +77,9 @@ struct Canvas {
     background_color: Color,
     /// If the canvas is a fixed size, that size
     size: Option<(u32, u32)>,
+    cell_width: f64,
+    cell_height: f64,
+    cell_baseline: f64,
 }
 
 impl Canvas {
@@ -125,7 +116,14 @@ impl Canvas {
             context,
             background_color,
             size,
+            cell_width: 10.0,
+            cell_height: 19.0,
+            cell_baseline: 0.0,
         })
+    }
+
+    fn init_ctx(&self) {
+        self.context.set_font("16px monospace");
     }
 
     /// Returns true if the size changed
@@ -141,11 +139,11 @@ impl Canvas {
             .ok_or(Error::UnableToRetrieveWindow)?
             .device_pixel_ratio();
 
-        let source_w = (width as f64 / CELL_WIDTH).ceil();
-        let source_h = (height as f64 / CELL_HEIGHT).ceil();
+        let source_w = (width as f64 / self.cell_width).ceil();
+        let source_h = (height as f64 / self.cell_height).ceil();
 
-        let canvas_w = source_w * CELL_WIDTH;
-        let canvas_h = source_h * CELL_HEIGHT;
+        let canvas_w = source_w * self.cell_width;
+        let canvas_h = source_h * self.cell_height;
 
         let change_size = self.inner.width() != (canvas_w * ratio) as u32
             || self.inner.height() != (canvas_h * ratio) as u32;
@@ -160,12 +158,28 @@ impl Canvas {
                 .style()
                 .set_property("height", &format!("{}px", canvas_h))?;
 
-            self.context.set_font("16px monospace");
-            self.context.set_text_baseline("top");
+            self.init_ctx();
             self.context.scale(ratio, ratio)?;
         }
 
         Ok(change_size.then_some((source_w as usize, source_h as usize)))
+    }
+
+    fn measure_font(&mut self) -> Result<(), Error> {
+        let metrics = self.context.measure_text("█")?;
+
+        if metrics.actual_bounding_box_right() > 0.0 {
+            self.cell_width = metrics.actual_bounding_box_right();
+        } else {
+            self.cell_width = metrics.width();
+        }
+
+        self.cell_height =
+            metrics.actual_bounding_box_ascent() + metrics.actual_bounding_box_descent();
+
+        self.cell_baseline = metrics.actual_bounding_box_descent();
+
+        Ok(())
     }
 }
 
@@ -226,7 +240,7 @@ impl CanvasBackend {
         // Parent element of canvas (uses <body> unless specified)
         let parent = get_element_by_id_or_body(options.grid_id.as_ref())?;
 
-        let canvas = Canvas::new(parent, options.size, Color::Black)?;
+        let mut canvas = Canvas::new(parent, options.size, Color::Black)?;
 
         let initialized = Rc::new(AtomicBool::new(false));
 
@@ -241,8 +255,10 @@ impl CanvasBackend {
             },
         )?;
 
-        let buffer = get_sized_buffer_from_canvas(&canvas.inner);
-        let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
+        let buffer = vec![vec![Cell::default()]];
+        let changed_cells = bitvec![0; 1];
+        canvas.init_ctx();
+        canvas.measure_font()?;
         Ok(Self {
             prev_buffer: buffer.clone(),
             always_clip_cells: options.always_clip_cells,
@@ -252,6 +268,7 @@ impl CanvasBackend {
             canvas,
             cursor_position: None,
             cursor_shape: CursorShape::SteadyBlock,
+            // debug_mode: Some("red".to_owned()),
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,
@@ -377,10 +394,10 @@ impl CanvasBackend {
 
                     self.canvas.context.begin_path();
                     self.canvas.context.rect(
-                        x as f64 * CELL_WIDTH,
-                        y as f64 * CELL_HEIGHT,
-                        CELL_WIDTH,
-                        CELL_HEIGHT,
+                        x as f64 * self.canvas.cell_width,
+                        y as f64 * self.canvas.cell_height,
+                        self.canvas.cell_width,
+                        self.canvas.cell_height,
                     );
                     self.canvas.context.clip();
 
@@ -399,8 +416,9 @@ impl CanvasBackend {
 
                 self.canvas.context.fill_text(
                     cell.symbol(),
-                    x as f64 * CELL_WIDTH,
-                    y as f64 * CELL_HEIGHT,
+                    x as f64 * self.canvas.cell_width,
+                    y as f64 * self.canvas.cell_height + self.canvas.cell_height
+                        - self.canvas.cell_baseline,
                 )?;
 
                 index += 1;
@@ -427,10 +445,10 @@ impl CanvasBackend {
 
             self.canvas.context.set_fill_style_str(&color);
             self.canvas.context.fill_rect(
-                rect.x as f64 * CELL_WIDTH,
-                rect.y as f64 * CELL_HEIGHT,
-                rect.width as f64 * CELL_WIDTH,
-                rect.height as f64 * CELL_HEIGHT,
+                (rect.x as f64 * self.canvas.cell_width).ceil(),
+                (rect.y as f64 * self.canvas.cell_height).ceil(),
+                (rect.width as f64 * self.canvas.cell_width).ceil(),
+                (rect.height as f64 * self.canvas.cell_height).ceil(),
             );
         };
 
@@ -469,8 +487,8 @@ impl CanvasBackend {
 
                 self.canvas.context.fill_text(
                     "_",
-                    pos.x as f64 * CELL_WIDTH,
-                    pos.y as f64 * CELL_HEIGHT,
+                    pos.x as f64 * self.canvas.cell_width,
+                    pos.y as f64 * self.canvas.cell_height,
                 )?;
 
                 self.canvas.context.restore();
@@ -489,10 +507,10 @@ impl CanvasBackend {
             for (x, _) in line.iter().enumerate() {
                 self.canvas.context.set_stroke_style_str(color);
                 self.canvas.context.stroke_rect(
-                    x as f64 * CELL_WIDTH,
-                    y as f64 * CELL_HEIGHT,
-                    CELL_WIDTH,
-                    CELL_HEIGHT,
+                    x as f64 * self.canvas.cell_width,
+                    y as f64 * self.canvas.cell_height,
+                    self.canvas.cell_width,
+                    self.canvas.cell_height,
                 );
             }
         }
@@ -606,8 +624,8 @@ impl Backend for CanvasBackend {
 
     fn size(&self) -> IoResult<Size> {
         Ok(Size::new(
-            self.buffer[0].len().saturating_sub(1) as u16,
-            self.buffer.len().saturating_sub(1) as u16,
+            self.buffer[0].len() as u16,
+            self.buffer.len() as u16,
         ))
     }
 
@@ -660,7 +678,7 @@ impl WebEventHandler for CanvasBackend {
         // Configure coordinate translation for canvas backend
         let config = MouseConfig::new(grid_width, grid_height)
             .with_offset(5.0) // Canvas translation offset
-            .with_cell_dimensions(CELL_WIDTH, CELL_HEIGHT);
+            .with_cell_dimensions(self.canvas.cell_width, self.canvas.cell_height);
 
         let element: web_sys::Element = self.canvas.inner.clone().into();
         let element_for_closure = element.clone();

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -308,7 +308,6 @@ impl CanvasBackend {
                 self.canvas.inner.client_height() as f64,
             );
         }
-        self.canvas.context.translate(5_f64, 5_f64)?;
 
         // NOTE: The draw_* functions each traverse the buffer once, instead of
         // traversing it once per cell; this is done to reduce the number of
@@ -321,7 +320,6 @@ impl CanvasBackend {
             self.draw_debug()?;
         }
 
-        self.canvas.context.translate(-5_f64, -5_f64)?;
         Ok(())
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -232,18 +232,16 @@ impl CanvasBackend {
 
         let initialized = Rc::new(AtomicBool::new(false));
 
-        if options.size.is_none() {
-            let closure = Closure::<dyn FnMut(_)>::new({
-                let initialized = Rc::clone(&initialized);
-                move |_: web_sys::Event| {
-                    initialized.store(false, Ordering::Relaxed);
-                }
-            });
-            web_sys::window()
-                .unwrap()
-                .set_onresize(Some(closure.as_ref().unchecked_ref()));
-            closure.forget();
-        }
+        let closure = Closure::<dyn FnMut(_)>::new({
+            let initialized = Rc::clone(&initialized);
+            move |_: web_sys::Event| {
+                initialized.store(false, Ordering::Relaxed);
+            }
+        });
+        web_sys::window()
+            .unwrap()
+            .set_onresize(Some(closure.as_ref().unchecked_ref()));
+        closure.forget();
 
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
@@ -545,7 +543,6 @@ impl Backend for CanvasBackend {
     fn flush(&mut self) -> IoResult<()> {
         // Only runs once.
         if !self.initialized.swap(true, Ordering::Relaxed) {
-            web_sys::console::log_1(&"in not initialized".into());
             if let Some(new_buffer_size) = self.canvas.init_ctx_and_resize()? {
                 self.buffer.resize_with(new_buffer_size.1, || {
                     vec![Cell::default(); new_buffer_size.0]

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -142,8 +142,8 @@ impl Canvas {
             .ok_or(Error::UnableToRetrieveWindow)?
             .device_pixel_ratio();
 
-        let source_w = (width as f64 / CELL_WIDTH).floor();
-        let source_h = (height as f64 / CELL_HEIGHT).floor();
+        let source_w = (width as f64 / self.cell_width).floor();
+        let source_h = (height as f64 / self.cell_height).floor();
 
         let canvas_w = source_w * self.cell_width;
         let canvas_h = source_h * self.cell_height;
@@ -175,7 +175,7 @@ impl Canvas {
         if metrics.actual_bounding_box_right() > 0.0 {
             self.cell_width = metrics.actual_bounding_box_right();
         } else {
-            self.cell_width = metrics.width();
+            self.cell_width = metrics.width().ceil();
         }
 
         self.cell_height =

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -268,7 +268,6 @@ impl CanvasBackend {
             canvas,
             cursor_position: None,
             cursor_shape: CursorShape::SteadyBlock,
-            // debug_mode: Some("red".to_owned()),
             debug_mode: None,
             mouse_callback: None,
             key_callback: None,

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -165,6 +165,7 @@ impl Canvas {
         Ok(change_size.then_some((source_w as usize, source_h as usize)))
     }
 
+    // Very useful code from here https://github.com/ghostty-org/ghostty/blob/a88689ca754a6eb7dce6015b85ccb1416b5363d8/src/font/face/web_canvas.zig#L242
     fn measure_font(&mut self) -> Result<(), Error> {
         let metrics = self.context.measure_text("█")?;
 
@@ -413,6 +414,8 @@ impl CanvasBackend {
                     self.canvas.context.set_fill_style_str(&color);
                 }
 
+                // Very useful symbol positioning formulas from here
+                // https://github.com/ghostty-org/ghostty/blob/a88689ca754a6eb7dce6015b85ccb1416b5363d8/src/Surface.zig#L1589C5-L1589C10
                 self.canvas.context.fill_text(
                     cell.symbol(),
                     x as f64 * self.canvas.cell_width,

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -606,8 +606,8 @@ impl Backend for CanvasBackend {
 
     fn size(&self) -> IoResult<Size> {
         Ok(Size::new(
-            self.buffer[0].len().saturating_sub(1) as u16,
-            self.buffer.len().saturating_sub(1) as u16,
+            self.buffer[0].len() as u16,
+            self.buffer.len() as u16,
         ))
     }
 

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -141,8 +141,8 @@ impl Canvas {
             .ok_or(Error::UnableToRetrieveWindow)?
             .device_pixel_ratio();
 
-        let source_w = (width as f64 / CELL_WIDTH).ceil();
-        let source_h = (height as f64 / CELL_HEIGHT).ceil();
+        let source_w = (width as f64 / CELL_WIDTH).floor();
+        let source_h = (height as f64 / CELL_HEIGHT).floor();
 
         let canvas_w = source_w * CELL_WIDTH;
         let canvas_h = source_h * CELL_HEIGHT;

--- a/src/backend/canvas.rs
+++ b/src/backend/canvas.rs
@@ -1,6 +1,10 @@
 use bitvec::{bitvec, prelude::BitVec};
 use ratatui::{backend::ClearType, layout::Rect};
-use std::io::{Error as IoError, Result as IoResult};
+use std::{
+    io::{Error as IoError, Result as IoResult},
+    rc::Rc,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::{
     backend::{
@@ -24,7 +28,7 @@ use ratatui::{
 };
 use web_sys::{
     js_sys::{Boolean, Map},
-    wasm_bindgen::{JsCast, JsValue},
+    wasm_bindgen::{prelude::Closure, JsCast, JsValue},
 };
 
 /// Width of a single cell.
@@ -77,20 +81,30 @@ impl CanvasBackendOptions {
 struct Canvas {
     /// Canvas element.
     inner: web_sys::HtmlCanvasElement,
+    /// Canvas parent element.
+    parent: web_sys::Element,
     /// Rendering context.
     context: web_sys::CanvasRenderingContext2d,
     /// Background color.
     background_color: Color,
+    /// If the canvas is a fixed size, that size
+    size: Option<(u32, u32)>,
 }
 
 impl Canvas {
     /// Constructs a new [`Canvas`].
     fn new(
         parent_element: web_sys::Element,
-        width: u32,
-        height: u32,
+        size: Option<(u32, u32)>,
         background_color: Color,
     ) -> Result<Self, Error> {
+        let (width, height) = size.unwrap_or_else(|| {
+            (
+                parent_element.client_width() as u32,
+                parent_element.client_height() as u32,
+            )
+        });
+
         let canvas = create_canvas_in_element(&parent_element, width, height)?;
 
         let context_options = Map::new();
@@ -104,14 +118,58 @@ impl Canvas {
             .ok_or_else(|| Error::UnableToRetrieveCanvasContext)?
             .dyn_into::<web_sys::CanvasRenderingContext2d>()
             .expect("Unable to cast canvas context");
-        context.set_font("16px monospace");
-        context.set_text_baseline("top");
 
         Ok(Self {
             inner: canvas,
+            parent: parent_element,
             context,
             background_color,
+            size,
         })
+    }
+
+    /// Returns true if the size changed
+    fn init_ctx_and_resize(&self) -> Result<Option<(usize, usize)>, Error> {
+        let (width, height) = self.size.unwrap_or_else(|| {
+            (
+                self.parent.client_width() as u32,
+                self.parent.client_height() as u32,
+            )
+        });
+
+        let ratio = web_sys::window()
+            .ok_or(Error::UnableToRetrieveWindow)?
+            .device_pixel_ratio();
+
+        let source_w = (width as f64 / CELL_WIDTH).ceil();
+        let source_h = (height as f64 / CELL_HEIGHT).ceil();
+
+        let canvas_w = source_w * CELL_WIDTH;
+        let canvas_h = source_h * CELL_HEIGHT;
+
+        let change_size = self.inner.width() != (canvas_w * ratio) as u32
+            || self.inner.height() != (canvas_h * ratio) as u32;
+
+        if change_size {
+            self.inner.set_width((canvas_w * ratio) as u32);
+            self.inner.set_height((canvas_h * ratio) as u32);
+            self.inner
+                .style()
+                .set_property("width", &format!("{}px", canvas_w))
+                .map_err(|e| Error::JsValue(e))?;
+            self.inner
+                .style()
+                .set_property("height", &format!("{}px", canvas_h))
+                .map_err(|e| Error::JsValue(e))?;
+
+            self.context.set_font("16px monospace");
+            self.context.set_text_baseline("top");
+            self.context
+                .scale(ratio, ratio)
+                .map_err(|e| Error::JsValue(e))?;
+        }
+
+        Ok(change_size.then_some((source_w as usize, source_h as usize)))
     }
 }
 
@@ -121,7 +179,7 @@ impl Canvas {
 #[derive(Debug)]
 pub struct CanvasBackend {
     /// Whether the canvas has been initialized.
-    initialized: bool,
+    initialized: Rc<AtomicBool>,
     /// Always clip foreground drawing to the cell rectangle. Helpful when
     /// dealing with out-of-bounds rendering from problematic fonts. Enabling
     /// this option may cause some performance issues when dealing with large
@@ -170,18 +228,30 @@ impl CanvasBackend {
         // Parent element of canvas (uses <body> unless specified)
         let parent = get_element_by_id_or_body(options.grid_id.as_ref())?;
 
-        let (width, height) = options
-            .size
-            .unwrap_or_else(|| (parent.client_width() as u32, parent.client_height() as u32));
+        let canvas = Canvas::new(parent, options.size, Color::Black)?;
 
-        let canvas = Canvas::new(parent, width, height, Color::Black)?;
+        let initialized = Rc::new(AtomicBool::new(false));
+
+        if options.size.is_none() {
+            let closure = Closure::<dyn FnMut(_)>::new({
+                let initialized = Rc::clone(&initialized);
+                move |_: web_sys::Event| {
+                    initialized.store(false, Ordering::Relaxed);
+                }
+            });
+            web_sys::window()
+                .unwrap()
+                .set_onresize(Some(closure.as_ref().unchecked_ref()));
+            closure.forget();
+        }
+
         let buffer = get_sized_buffer_from_canvas(&canvas.inner);
         let changed_cells = bitvec![0; buffer.len() * buffer[0].len()];
         Ok(Self {
             prev_buffer: buffer.clone(),
             always_clip_cells: options.always_clip_cells,
             buffer,
-            initialized: false,
+            initialized,
             changed_cells,
             canvas,
             cursor_position: None,
@@ -474,10 +544,26 @@ impl Backend for CanvasBackend {
     /// actually render the content to the screen.
     fn flush(&mut self) -> IoResult<()> {
         // Only runs once.
-        if !self.initialized {
+        if !self.initialized.swap(true, Ordering::Relaxed) {
+            web_sys::console::log_1(&"in not initialized".into());
+            if let Some(new_buffer_size) = self.canvas.init_ctx_and_resize()? {
+                self.buffer.resize_with(new_buffer_size.1, || {
+                    vec![Cell::default(); new_buffer_size.0]
+                });
+                self.prev_buffer.resize_with(new_buffer_size.1, || {
+                    vec![Cell::default(); new_buffer_size.0]
+                });
+                for line in self.buffer.iter_mut() {
+                    line.resize_with(new_buffer_size.0, || Cell::default());
+                }
+                for line in self.prev_buffer.iter_mut() {
+                    line.resize_with(new_buffer_size.0, || Cell::default());
+                }
+                self.changed_cells
+                    .resize(new_buffer_size.0 * new_buffer_size.1, true);
+            }
             self.update_grid(true)?;
             self.prev_buffer = self.buffer.clone();
-            self.initialized = true;
             return Ok(());
         }
 
@@ -517,7 +603,10 @@ impl Backend for CanvasBackend {
     }
 
     fn clear(&mut self) -> IoResult<()> {
-        self.buffer = get_sized_buffer();
+        self.buffer
+            .iter_mut()
+            .flatten()
+            .for_each(|c| *c = Cell::default());
         Ok(())
     }
 

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -212,12 +212,6 @@ pub(crate) fn get_raw_screen_size() -> (i32, i32) {
     (s.width().unwrap(), s.height().unwrap())
 }
 
-/// Returns a buffer based on the screen size.
-pub(crate) fn get_sized_buffer() -> Vec<Vec<Cell>> {
-    let size = get_size();
-    vec![vec![Cell::default(); size.width as usize]; size.height as usize]
-}
-
 /// Returns a buffer size based on the screen size.
 pub(crate) fn get_size() -> Size {
     if is_mobile() {
@@ -225,13 +219,6 @@ pub(crate) fn get_size() -> Size {
     } else {
         get_window_size()
     }
-}
-
-/// Returns a buffer based on the canvas size.
-pub(crate) fn get_sized_buffer_from_canvas(canvas: &HtmlCanvasElement) -> Vec<Vec<Cell>> {
-    let width = canvas.client_width() as u16 / 10_u16;
-    let height = canvas.client_height() as u16 / 19_u16;
-    vec![vec![Cell::default(); width as usize]; height as usize]
 }
 
 /// Returns the document object from the window.


### PR DESCRIPTION
This PR builds on #162 and adds the ability for the canvas backend to calculate the correct cell width and height for the monospace font being used.