### PR TITLE
feat(webgl2): add `cell_size()` and `set_size()`  to `WebGl2Backend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,29 +32,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "beamterm-data"
-version = "0.15.0"
+name = "beamterm-core"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7927a4e9de1e0028f777ace6cd5cd5e8d7f87a5cfec44a4f8dc135f18bc1f0e"
-dependencies = [
- "compact_str",
- "miniz_oxide",
-]
-
-[[package]]
-name = "beamterm-renderer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0d1b38455b427293dffbb0eb970c91c04f8ab32cb47b3884ed46924fda5819"
+checksum = "dd35ff2f9ffbbacf0a201cc76251d7489420d73f30e0efa34fe6f2ff640ba9fb"
 dependencies = [
  "beamterm-data",
  "bitflags",
  "compact_str",
- "console_error_panic_hook",
  "emojis",
- "js-sys",
+ "glow",
  "lru",
  "rustc-hash",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "beamterm-data"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0a5d2b82a5e8cfe1495e63a677d4b5a973ecc88b156034bdec9023bd0853f2"
+dependencies = [
+ "compact_str",
+ "miniz_oxide",
+ "thiserror",
+]
+
+[[package]]
+name = "beamterm-renderer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bb8475a1f3a8814b83c7c406721f0e7f295ed619dec281918f47b4a243fbfd"
+dependencies = [
+ "beamterm-core",
+ "beamterm-data",
+ "bitflags",
+ "compact_str",
+ "console_error_panic_hook",
+ "glow",
+ "js-sys",
  "thiserror",
  "unicode-width",
  "wasm-bindgen",
@@ -253,6 +270,18 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -669,6 +698,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +828,12 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 dependencies = [
  "rustc-std-workspace-core",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ ratatui = { version = "0.30", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.18"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.15.0"
+beamterm-renderer = "0.16.0"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -427,6 +427,27 @@ impl WebGl2Backend {
         Ok(())
     }
 
+    /// Returns the cell size in physical pixels at the current device
+    /// pixel ratio.
+    ///
+    /// For static atlases, this is the cell size from the atlas data.
+    /// For dynamic atlases, this is measured from the rasterized font.
+    pub fn cell_size(&self) -> (i32, i32) {
+        self.beamterm.cell_size()
+    }
+
+    /// Resizes the canvas and terminal grid to the specified logical pixel dimensions.
+    ///
+    /// This updates the canvas buffer, CSS display size (if auto-resize is enabled),
+    /// viewport, and recalculates the terminal grid dimensions based on the current
+    /// cell size.
+    pub fn set_size(&mut self, width: u32, height: u32) -> Result<(), Error> {
+        self.beamterm.resize(width as i32, height as i32)?;
+        self.cursor_over_hyperlink = false;
+        self.update_mouse_handler_metrics();
+        Ok(())
+    }
+
     /// Updates metrics on externally-managed mouse handlers after resize or DPR changes.
     ///
     /// Beamterm's `Terminal::resize()` only updates its own internal mouse handler.


### PR DESCRIPTION
updates beamterm to [0.16.0](https://github.com/junkdog/beamterm/releases/tag/beamterm-v0.16.0); nothing especially exciting for ratzilla, but it does fix https://github.com/ratatui/ratzilla/issues/160 and  a corner-case bug around the atlas encoding leading to potentially lost glyphs. 

## WebGl2Backend - new pub methods

`cell_size()` exposes the current cell dimensions in native pixels. this is required for e.g. supporting the dynamic font atlas in [tachyonfx-renderer](https://github.com/junkdog/tachyonfx-renderer/).  it also brings us one step closer to exposing cell_size() for all backends

`set_size()` resizes the terminal to fit the given size (css display size).

(these overlapping sets of pixel units is frustrating - we might want to consider wrapping everything in proper types, in the interest of maintainability).