### PR TITLE
chore(deps): bump beamterm to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "beamterm-core"
-version = "0.16.0"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ede1fea2497ca8e830cfef6e12476cef80fe9fdb5a4088a7d61a2eb24a69b67"
 dependencies = [
  "beamterm-data",
  "bitflags",
@@ -48,7 +50,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-data"
-version = "0.16.0"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807afb61cd85b78f4218c8f10c8a2ee12ee22b4504ac99b1ac7c4d11412336b8"
 dependencies = [
  "compact_str",
  "miniz_oxide",
@@ -57,7 +61,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-renderer"
-version = "0.16.0"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf24d97fcf8104c12e4e394c8fac55576bca0ee25bd70d9eac87ac72987d3e5"
 dependencies = [
  "beamterm-core",
  "beamterm-data",
@@ -268,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "beamterm-core"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd35ff2f9ffbbacf0a201cc76251d7489420d73f30e0efa34fe6f2ff640ba9fb"
 dependencies = [
  "beamterm-data",
  "bitflags",
@@ -51,8 +49,6 @@ dependencies = [
 [[package]]
 name = "beamterm-data"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0a5d2b82a5e8cfe1495e63a677d4b5a973ecc88b156034bdec9023bd0853f2"
 dependencies = [
  "compact_str",
  "miniz_oxide",
@@ -62,8 +58,6 @@ dependencies = [
 [[package]]
 name = "beamterm-renderer"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bb8475a1f3a8814b83c7c406721f0e7f295ed619dec281918f47b4a243fbfd"
 dependencies = [
  "beamterm-core",
  "beamterm-data",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ ratatui = { version = "0.30", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.18"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.16.0"
+beamterm-renderer = { path = "../beamterm/beamterm-renderer" } 
+# beamterm-renderer = "0.16.0"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,7 @@ ratatui = { version = "0.30", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.18"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = { path = "../beamterm/beamterm-renderer" } 
-# beamterm-renderer = "0.16.0"
+beamterm-renderer = "0.17.0"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -373,7 +373,7 @@ impl WebGl2Backend {
             (None, None)
         };
 
-        let mut backend = Self {
+        Ok(Self {
             beamterm,
             cursor_position: None,
             options,
@@ -384,12 +384,7 @@ impl WebGl2Backend {
             hyperlink_state,
             _user_mouse_handler: None,
             _user_key_handler: None,
-        };
-
-        // Convert handler metrics from physical pixels to CSS pixels
-        backend.update_mouse_handler_metrics();
-
-        Ok(backend)
+        })
     }
 
     /// Returns the options objects used to create this backend.
@@ -422,8 +417,6 @@ impl WebGl2Backend {
         // Reset hyperlink cursor state when canvas is resized
         self.cursor_over_hyperlink = false;
 
-        self.update_mouse_handler_metrics();
-
         Ok(())
     }
 
@@ -444,30 +437,7 @@ impl WebGl2Backend {
     pub fn set_size(&mut self, width: u32, height: u32) -> Result<(), Error> {
         self.beamterm.resize(width as i32, height as i32)?;
         self.cursor_over_hyperlink = false;
-        self.update_mouse_handler_metrics();
         Ok(())
-    }
-
-    /// Updates metrics on externally-managed mouse handlers after resize or DPR changes.
-    ///
-    /// Beamterm's `Terminal::resize()` only updates its own internal mouse handler.
-    /// The user and hyperlink handlers created by ratzilla need their metrics updated
-    /// separately.
-    fn update_mouse_handler_metrics(&mut self) {
-        let (cols, rows) = self.beamterm.terminal_size();
-        let (phys_w, phys_h) = self.beamterm.cell_size();
-        let dpr = window()
-            .map(|w| w.device_pixel_ratio() as f32)
-            .unwrap_or(1.0);
-        let cell_width = phys_w as f32 / dpr;
-        let cell_height = phys_h as f32 / dpr;
-
-        if let Some(handler) = &mut self._user_mouse_handler {
-            handler.update_metrics(cols, rows, cell_width, cell_height);
-        }
-        if let Some(handler) = &mut self._hyperlink_mouse_handler {
-            handler.update_metrics(cols, rows, cell_width, cell_height);
-        }
     }
 
     /// Checks if the canvas size matches the display size and resizes it if necessary.
@@ -923,10 +893,6 @@ impl WebEventHandler for WebGl2Backend {
         )?;
 
         self._user_mouse_handler = Some(mouse_handler);
-
-        // TerminalMouseHandler is constructed with physical pixel metrics;
-        // convert to CSS pixels so coordinate translation is correct on HiDPI.
-        self.update_mouse_handler_metrics();
 
         Ok(())
     }


### PR DESCRIPTION
fixes the the re-introduced cursor offset bug when zooming the browser window.

beamterm now tracks dirty regions; cells are divided into chunks of 1024 cells (8kb upload). adjacent dirty regions are merged to minimize the number of `glBufferSubData` calls per frame.