### PR TITLE
chore(deps): bump to beamterm 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,11 +33,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "beamterm-core"
-version = "0.18.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e70ac4f44721725e32ca1c696dc5723993a1d744e072afeb0bfdc5c4b110b8"
+checksum = "0375f7f3df163a52a06807f2150bac9a5da1933864ed40d52dda7dcd7cfa193b"
 dependencies = [
  "beamterm-data",
+ "beamterm-unicode",
  "bitflags",
  "compact_str",
  "glow",
@@ -49,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-data"
-version = "0.18.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6facd8893c0b6c3fc51f43e8fb1bbfa91b3e902807ea8a654ee05c4eb2a1d48"
+checksum = "f21ff1fc630079352bae9b024f85519bf1f641cf7f326623f4c0b59f7ea834fd"
 dependencies = [
  "compact_str",
  "miniz_oxide",
@@ -60,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-renderer"
-version = "0.18.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b839bf3c4add79b4a70fc0ce3c397eb364b0f2dad2c648644bf3fd76520b5df9"
+checksum = "d8db76d04d575a0534ad5dba63acc05ccbe69597f977f11c59a612cbea199112"
 dependencies = [
  "beamterm-core",
  "beamterm-data",
@@ -76,6 +77,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "beamterm-unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f44155933cdd0625a699c554c504aab30a571e4df68f3532fb95bf9cf53b935"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,14 +33,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "beamterm-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ede1fea2497ca8e830cfef6e12476cef80fe9fdb5a4088a7d61a2eb24a69b67"
+checksum = "73e70ac4f44721725e32ca1c696dc5723993a1d744e072afeb0bfdc5c4b110b8"
 dependencies = [
  "beamterm-data",
  "bitflags",
  "compact_str",
- "emojis",
  "glow",
  "lru",
  "rustc-hash",
@@ -50,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-data"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807afb61cd85b78f4218c8f10c8a2ee12ee22b4504ac99b1ac7c4d11412336b8"
+checksum = "a6facd8893c0b6c3fc51f43e8fb1bbfa91b3e902807ea8a654ee05c4eb2a1d48"
 dependencies = [
  "compact_str",
  "miniz_oxide",
@@ -61,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "beamterm-renderer"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf24d97fcf8104c12e4e394c8fac55576bca0ee25bd70d9eac87ac72987d3e5"
+checksum = "b839bf3c4add79b4a70fc0ce3c397eb364b0f2dad2c648644bf3fd76520b5df9"
 dependencies = [
  "beamterm-core",
  "beamterm-data",
@@ -207,15 +206,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "emojis"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1c1870b766fc398e5f0526498d09c94b6de15be5fd769a28bbc804fb1b05d"
-dependencies = [
- "phf",
-]
 
 [[package]]
 name = "equivalent"
@@ -473,24 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,12 +656,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ ratatui = { version = "0.30", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.18"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.18.0"
+beamterm-renderer = "1"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ ratatui = { version = "0.30", default-features = false, features = ["all-widgets
 console_error_panic_hook = "0.1.7"
 thiserror = "2.0.18"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "std"] }
-beamterm-renderer = "0.17.0"
+beamterm-renderer = "0.18.0"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/src/backend/webgl2.rs
+++ b/src/backend/webgl2.rs
@@ -7,7 +7,7 @@ use crate::{
     error::Error,
     event::{KeyEvent, MouseEvent},
     render::WebEventHandler,
-    CursorShape,
+    CellSized, CursorShape,
 };
 pub use beamterm_renderer::SelectionMode;
 use beamterm_renderer::{
@@ -29,7 +29,6 @@ use std::{
 };
 use web_sys::{wasm_bindgen::JsCast, Element};
 
-use crate::backend::cell_sized::CellSized;
 /// Re-export beamterm's atlas data type. Used by [`FontAtlasConfig::Static`].
 pub use beamterm_renderer::FontAtlasData;
 
@@ -680,8 +679,8 @@ impl WebGl2Backend {
 
 impl CellSized for WebGl2Backend {
     fn cell_size_px(&self) -> (f32, f32) {
-        let (w, h) = self.beamterm.cell_size();
-        (w as f32, h as f32)
+        let cs = self.beamterm.cell_size();
+        (cs.width as f32, cs.height as f32)
     }
 
     fn cell_size_css_px(&self) -> (f32, f32) {
@@ -747,16 +746,16 @@ impl Backend for WebGl2Backend {
     }
 
     fn size(&self) -> IoResult<Size> {
-        let (w, h) = self.beamterm.terminal_size();
-        Ok(Size::new(w, h))
+        let ts = self.beamterm.terminal_size();
+        Ok(Size::new(ts.cols, ts.rows))
     }
 
     fn window_size(&mut self) -> IoResult<WindowSize> {
-        let (cols, rows) = self.beamterm.terminal_size();
+        let ts = self.beamterm.terminal_size();
         let (w, h) = self.beamterm.canvas_size();
 
         Ok(WindowSize {
-            columns_rows: Size::new(cols, rows),
+            columns_rows: Size::new(ts.cols, ts.rows),
             pixels: Size::new(w as _, h as _),
         })
     }


### PR DESCRIPTION
probably (hopefully) the last bump in a while. version should be `cargo update`-able too, going forward.

the release is otherwise pretty uninteresting from a ratzilla pov. dropped at least one dep, so that's good.

~beamterm 1.0.0 will probably be released before the next ratzilla release, so might as well hold off on merging. 0.18.0 mostly revolves around native/not-wasm stuff + final api audit.~