### PR TITLE
fix(ci): do caching correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
           components: rustfmt
       - name: check formatting
         run: cargo fmt -- --check
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
 
   clippy:
     name: clippy
@@ -41,10 +39,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Run clippy action
-        uses: clechasseur/rs-clippy-check@v3
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+      - name: Run clippy action
+        uses: clechasseur/rs-clippy-check@v3
 
   doc:
     name: doc
@@ -53,6 +51,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Run cargo doc
         run: cargo doc --no-deps --all-features
         env:
@@ -73,6 +73,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
@@ -80,8 +82,6 @@ jobs:
         run: cargo test --locked --all-features --all-targets
       - name: cargo test --doc
         run: cargo test --doc --all-features
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Run browser headless tests
         run: wasm-pack test --firefox --headless
 
@@ -105,6 +105,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Cargo check
         # we need to move the generated project to a temp folder, away from the template project

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Build website
         shell: bash
         run: scripts/build-examples.sh

--- a/templates/simple/.github/workflows/ci.yml
+++ b/templates/simple/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
           components: rustfmt
       - name: check formatting
         run: cargo fmt -- --check
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
   clippy:
     name: clippy
     runs-on: ubuntu-latest
@@ -44,10 +42,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Run clippy action
-        uses: clechasseur/rs-clippy-check@v3
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+      - name: Run clippy action
+        uses: clechasseur/rs-clippy-check@v3
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
@@ -79,11 +77,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
       # enable this ci template to run regardless of whether the lockfile is checked in or not
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo test --locked
         run: cargo test --locked --all-features --all-targets
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Essentially the same fixes as in https://github.com/ratatui/mousefood/pull/190, but in a bigger scale.

I think we will save A LOT of time by doing caching correctly here!

Formatting doesn't build, so doesn't need caching, and in the other places the cache step (which is a _restore_ step) is done after it would be useful.