### PR TITLE
docs(readme): add MTUI to websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ There is a Vercel deployment template available for Ratzilla [here](https://verc
 - <https://sdr-geo-db.vercel.app/> - SDR contact logging database ([source](https://github.com/nuts-rice/sdr_geo_db))
 - <https://kana.rezoleo.fr> - Learn Kana in a terminal fashion ([source](https://github.com/benoitlx/kanash))
 - <https://shenoi.dev/twozero48> - A 2048 game ([source](https://github.com/de-sh/twozero48))
+- <https://inowattio.github.io/MTUI/> - Modbus Client ([source]([https://github.com/de-sh/twozero48](https://github.com/inowattio/MTUI)))
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ There is a Vercel deployment template available for Ratzilla [here](https://verc
 - <https://sdr-geo-db.vercel.app/> - SDR contact logging database ([source](https://github.com/nuts-rice/sdr_geo_db))
 - <https://kana.rezoleo.fr> - Learn Kana in a terminal fashion ([source](https://github.com/benoitlx/kanash))
 - <https://shenoi.dev/twozero48> - A 2048 game ([source](https://github.com/de-sh/twozero48))
-- <https://inowattio.github.io/MTUI/> - Modbus Client ([source]([https://github.com/de-sh/twozero48](https://github.com/inowattio/MTUI)))
+- <https://inowattio.github.io/MTUI/> - Modbus Client ([source](https://github.com/inowattio/MTUI))
 
 ## Acknowledgements
 


### PR DESCRIPTION
https://github.com/inowattio/MTUI is a very extensive Modbus Client in TUI.
Generally, this would be native only executable as it relies on serial/sockets, but I've managed to make it into a [web demo](https://inowattio.github.io/MTUI/) by adding a mock device implementation and of course, by using ratzilla!